### PR TITLE
[HID-1790] Set a service on Snap calls, also pass User-Agent and remote IP.

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -66,6 +66,7 @@ async function _pdfExport(users, number, lists, req, format) {
   const hostname = process.env.WKHTMLTOPDF_HOST;
   const port = process.env.WKHTMLTOPDF_PORT || 80;
   const params = {
+    service: 'hid-api',
     pdfLandscape: true,
     pdfBackground: true,
     pdfMarginUnit: 'mm',
@@ -82,6 +83,8 @@ async function _pdfExport(users, number, lists, req, format) {
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
       'Content-Length': postData.length,
+      'X-Forwarded-For': req.headers['x-forwarded-for'] || req.connection.remoteAddress,
+      'User-Agent': req.headers['user-agent'],
     },
     data: postData,
     responseType: 'arraybuffer',


### PR DESCRIPTION
This allows the Snap Service usage report to label HID calls properly.

I *think* I'm passing the correct `req.headers[]` but please do double check, as JS is not my forté.