### PR TITLE
HID-1807: update wording of reset notifications

### DIFF
--- a/emails/forced_password_reset/fr/html.ejs
+++ b/emails/forced_password_reset/fr/html.ejs
@@ -1,11 +1,10 @@
 <p>Bonjour <%= user.name %>,</p>
 
-<p>Conformément aux règlements de l'ONU, les mots de passe, comme mesure de sécurité, doivent être mis à jour tous les six mois. Nous souhaitons vous rappeler que votre mot de passe expirera aujourd'hui.
-  Sachez qu'une fois que le mot de passe expiré, vous ne pourrez plus accéder au site Web HumanitarianID ni aux site webs partenaires.</p>
+<p>Conformément aux règlements de l'ONU, le mot de passe, comme mesure de sécurité, doit être changé tous les six mois. Nous souhaitons vous rappeler que votre mot de passe expirera aujourd'hui. Sachez qu'une fois que le mot de passe expiré, vous ne pourrez plus accéder au site Web <a href="https://humanitarian.id">Humanitarian ID</a> ni aux site webs <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partenaires</a>.</p>
 
 <p>Pour changer votre mot de passe, cliquez simplement sur le lien suivant : <a href="https://auth.humanitarian.id/password">https://auth.humanitarian.id/password</a></p>
 
-<p>Ou encore, si vous avez un profil sur HumanitarianID, vous pouvez également changer le mot de passe en cliquant sur votre nom, puis sur "Préférences" et "Modifier le mot de passe".</p>
+<p>Vous pouvez également modifier votre mot de passe à partir de votre profil sur le site web de Humanitarian ID.</p>
 
 <p>Si vous avez des questions, n'hésitez pas à nous contacter : info@humanitarian.id</p>
 

--- a/emails/forced_password_reset/html.ejs
+++ b/emails/forced_password_reset/html.ejs
@@ -1,11 +1,10 @@
 <p>Dear <%= user.name %>,</p>
 
-<p>Following UN regulations, as a security measure passwords must be updated every six months. We would like to remind you that your Humanitarian ID password will expire today.
-  Please be informed that once the password expires you will not be able to access the <a href="https://humanitarian.id">Humanitarian ID</a> website and any of the <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partner platforms</a>.</p>
+<p>Following UN regulations, as a security measure passwords must be changed every six months. We would like to remind you that your Humanitarian ID password will expire today. Please be informed that once the password expires you will not be able to access the <a href="https://humanitarian.id">Humanitarian ID</a> website and any of the <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partner platforms</a>.</p>
 
 <p>To change your password, simply click on the following link: <a href="https://auth.humanitarian.id/password">https://auth.humanitarian.id/password</a></p>
 
-<p>Or alternatively, you can also change the password by clicking on your name, then "Preferences" and "Change Password".</p>
+<p>You can also change your password from your profile in the Humanitarian ID website.</p>
 
 <p>If you have any questions, do not hesitate to contact us: info@humanitarian.id</p>
 

--- a/emails/forced_password_reset_alert/fr/html.ejs
+++ b/emails/forced_password_reset_alert/fr/html.ejs
@@ -1,11 +1,10 @@
 <p>Bonjour <%= user.name %>,</p>
 
-<p>Conformément aux règlements de l'ONU, les mots de passe, comme mesure de sécurité, doivent être mis à jour tous les six mois. Nous souhaitons vous rappeler que votre mot de passe expirera dans 30 jours.
-  Sachez qu'une fois que le mot de passe expiré, vous ne pourrez plus accéder au site Web HumanitarianID ni aux site webs partenaires.</p>
+<p>Conformément aux règlements de l'ONU, le mot de passe, comme mesure de sécurité, doit être changé tous les six mois. Nous souhaitons vous rappeler que votre mot de passe expirera dans 30 jours. Sachez qu'une fois que le mot de passe expiré, vous ne pourrez plus accéder au site Web <a href="https://humanitarian.id">Humanitarian ID</a> ni aux site webs <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partenaires</a>.</p>
 
 <p>Pour changer votre mot de passe, cliquez simplement sur le lien suivant : <a href="https://auth.humanitarian.id/password">https://auth.humanitarian.id/password</a></p>
 
-<p>Ou encore, si vous avez un profil sur HumanitarianID, vous pouvez également changer le mot de passe en cliquant sur votre nom, puis sur "Préférences" et "Modifier le mot de passe".</p>
+<p>Vous pouvez également modifier votre mot de passe à partir de votre profil sur le site web de Humanitarian ID.</p>
 
 <p>Si vous avez des questions, n'hésitez pas à nous contacter : info@humanitarian.id</p>
 

--- a/emails/forced_password_reset_alert/html.ejs
+++ b/emails/forced_password_reset_alert/html.ejs
@@ -1,11 +1,10 @@
 <p>Dear <%= user.name %>,</p>
 
-<p>Following UN regulations, as a security measure passwords must be updated every six months. We would like to remind you that your Humanitarian ID password is about to expire in 30 days.
-  Please be informed that once the password expires you will not be able to access the <a href="https://humanitarian.id">Humanitarian ID</a> website and any of the <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partner platforms</a>.</p>
+<p>Following UN regulations, as a security measure passwords must be changed every six months. We would like to remind you that your Humanitarian ID password is about to expire in 30 days. Please be informed that once the password expires you will not be able to access the <a href="https://humanitarian.id">Humanitarian ID</a> website and any of the <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partner platforms</a>.</p>
 
 <p>To change your password, simply click on the following link: <a href="https://auth.humanitarian.id/password">https://auth.humanitarian.id/password</a></p>
 
-<p>Or alternatively, you can also change the password by clicking on your name, then "Preferences" and "Change Password".</p>
+<p>You can also change your password from your profile in the Humanitarian ID website.</p>
 
 <p>If you have any questions, do not hesitate to contact us: info@humanitarian.id</p>
 

--- a/emails/forced_password_reset_alert7/fr/html.ejs
+++ b/emails/forced_password_reset_alert7/fr/html.ejs
@@ -1,11 +1,10 @@
 <p>Bonjour <%= user.name %>,</p>
 
-<p>Conformément aux règlements de l'ONU, les mots de passe, comme mesure de sécurité, doivent être mis à jour tous les six mois. Nous souhaitons vous rappeler que votre mot de passe expirera dans 7 jours.
-  Sachez qu'une fois que le mot de passe expiré, vous ne pourrez plus accéder au site Web HumanitarianID ni aux site webs partenaires.</p>
+<p>Conformément aux règlements de l'ONU, le mot de passe, comme mesure de sécurité, doit être changé tous les six mois. Nous souhaitons vous rappeler que votre mot de passe expirera dans sept jours. Sachez qu'une fois que le mot de passe expiré, vous ne pourrez plus accéder au site Web <a href="https://humanitarian.id">Humanitarian ID</a> ni aux site webs <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partenaires</a>.</p>
 
 <p>Pour changer votre mot de passe, cliquez simplement sur le lien suivant : <a href="https://auth.humanitarian.id/password">https://auth.humanitarian.id/password</a></p>
 
-<p>Ou encore, si vous avez un profil sur HumanitarianID, vous pouvez également changer le mot de passe en cliquant sur votre nom, puis sur "Préférences" et "Modifier le mot de passe".</p>
+<p>Vous pouvez également modifier votre mot de passe à partir de votre profil sur le site web de Humanitarian ID.</p>
 
 <p>Si vous avez des questions, n'hésitez pas à nous contacter : info@humanitarian.id</p>
 

--- a/emails/forced_password_reset_alert7/html.ejs
+++ b/emails/forced_password_reset_alert7/html.ejs
@@ -1,11 +1,10 @@
 <p>Dear <%= user.name %>,</p>
 
-<p>Following UN regulations, as a security measure passwords must be updated every six months. We would like to remind you that your Humanitarian ID password will expire in seven days.
-  Please be informed that once the password expires you will not be able to access the <a href="https://humanitarian.id">Humanitarian ID</a> website and any of the <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partner platforms</a>.</p>
+<p>Following UN regulations, as a security measure passwords must be changed every six months. We would like to remind you that your Humanitarian ID password is about to expire in seven days. Please be informed that once the password expires you will not be able to access the <a href="https://humanitarian.id">Humanitarian ID</a> website and any of the <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partner platforms</a>.</p>
 
 <p>To change your password, simply click on the following link: <a href="https://auth.humanitarian.id/password">https://auth.humanitarian.id/password</a></p>
 
-<p>Or alternatively, you can also change the password by clicking on your name, then "Preferences" and "Change Password".</p>
+<p>You can also change your password from your profile in the Humanitarian ID website.</p>
 
 <p>If you have any questions, do not hesitate to contact us: info@humanitarian.id</p>
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/HID-1807

Changes to the email notification templates. I noticed that there were trivial differences between the templates and opted to make them all conform to one convention.

* The first long paragraph had a line-break in french, but not in the new text I was supplied in English. I turned it into one paragraph
* The links present in the English were not in the templates for French. I've added them to French. I don't speak French so please make sure the text inside the links is coherent.