### PR TITLE
HID-1817: update libphonenumber

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ejs": "^2.5.2",
     "email-templates": "^5.0.2",
     "google-auth-library": "^2.0.2",
-    "google-libphonenumber": "^3.1.6",
+    "google-libphonenumber": "^3.2.3",
     "googleapis": "^36.0.0",
     "hapi": "^18.1.0",
     "hapi-rate-limit": "^3.1.1",


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/HID-1817

Blocks https://github.com/UN-OCHA/hid_app2/pull/147

Without this update, the client-side library can validate but then the visitor is shown an error when clicking the <kbd>+</kbd> button.