### PR TITLE
HID-1838: add more authorized domains for development/testing

### DIFF
--- a/api/services/HelperService.js
+++ b/api/services/HelperService.js
@@ -11,6 +11,7 @@ const queryOptions = [
 const authorizedDomains = [
   'https://humanitarian.id',
   'https://auth.humanitarian.id',
+  'https://app.cd.dev.humanitarian.id',
   'https://app.dev.humanitarian.id',
   'https://api.dev.humanitarian.id',
   'https://api.humanitarian.id',
@@ -18,6 +19,8 @@ const authorizedDomains = [
   'https://api.staging.humanitarian.id',
   'https://app.staging.humanitarian.id',
   'https://api.hid.vm',
+  'https://app.hid.vm',
+  'http://app.hid.vm',
 ];
 
 /**


### PR DESCRIPTION
Adding some authorized domains for CD QA plus local testing.

* The app.cd domain is for our CD QA environment
* The app.hid.vm are for localtesting. Non-HTTPS is included to facilitate cross-browser testing via BrowserStack