### PR TITLE
HID-1865 - Fixed 400 bad request issue

### DIFF
--- a/plugins/hapi-auth-hid/index.js
+++ b/plugins/hapi-auth-hid/index.js
@@ -104,7 +104,6 @@ internals.implementation = () => ({
       if (!user) {
         throw Boom.unauthorized('No user found');
       }
-      request.params.currentUser = user;
       delete request.query.bewit;
       logger.info('Successful authentication through bewit', { security: true, user: attributes.id, request });
       return reply.authenticated({


### PR DESCRIPTION
This is a leftover of the old way users were being authenticated. In older versions of hapi, hapi didn't provide an out-of-the-box variable to store the current user, so I was storing it in request.params.currentUser. When hapi was upgraded to version 17, it provided a variable (request.auth.credentials), so I changed my authentication plugin to use this new variable, but missed removing the line that was storing the current user in request.params.currentUser. 

It was still working until I added validation of the request parameters (see https://github.com/UN-OCHA/hid_api/commit/fddb254f5d9b43422d5d1fe978ab4ae8457026ca#diff-a9a8d893a8463ac387317e02eec99c96). When request parameters started being validated, Joi (the validation framework) started rejecting the requests because "currentUser" was not part of the allowed request parameters, returning the 400 http error we were seeing.