### PR TITLE
HID-1879: add new ToS link to HID Auth footer

### DIFF
--- a/templates/footer.ejs
+++ b/templates/footer.ejs
@@ -17,6 +17,9 @@
             <li class="footer-links__item">
               <a href="https://about.humanitarian.id/code-of-conduct/" class="footer-links__link" translate>Code of conduct</a>
             </li>
+            <li class="footer-links__item">
+              <a href="https://about.humanitarian.id/terms-of-service/" class="footer-links__link" translate>Terms of Service</a>
+            </li>
             <li class="footer-links__item last">
               <a href="mailto:info@humanitarian.id" class="footer-links__link" translate>Contact</a>
             </li>


### PR DESCRIPTION
## HID-1879

Auth page was missing new ToS link. easy fix.