### PR TITLE
HID-1878: use Edge-compatible window.CSS.supports query

### DIFF
--- a/templates/header.ejs
+++ b/templates/header.ejs
@@ -92,7 +92,7 @@
   document.documentElement.classList.remove('no-js');
 
   // Feature detection for CSS Grid
-  if (window.CSS && window.CSS.supports && window.CSS.supports('display: grid')) {
+  if (window.CSS && window.CSS.supports && window.CSS.supports('display','grid')) {
     document.documentElement.classList.remove('no-cssgrid');
     document.documentElement.classList.add('cssgrid');
   }


### PR DESCRIPTION
## HID-1878

The CD Header column headings and "See All" button were distorted in Edge.

I was using `window.CSS.supports('display: grid')` and Edge 18 didn't seem to like that syntax. Switching to `window.CSS.supports('display', 'grid')` cleared it up without regressions in other browsers.