### PR TITLE
[OPS-6231] minimal edits to make this docker-compose actually work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   db:
     image: unocha/mongo:4.0.5
     volumes:
-      - ./db:/srv/db
       - ./data:/srv
+      - ./db:/srv/db
       - .:/srv/www
     environment:
       DNSDOCK_NAME: db


### PR DESCRIPTION
Only for the target branch!
Not needed elsewhere.

Fixes this errors in the hpc dev setup script:

```
Recreating 96357ceb011b_hid_api_db_1 ... error

ERROR: for 96357ceb011b_hid_api_db_1  Cannot start service db: OCI runtime create failed: container_linux.go:346: starting container process caused "process_linux.go:449: container init caused \"rootfs_linux.go:58: mounting \\\"/Users/serban/Projects/OCHA/HPC/hid_api/db\\\" to rootfs \\\"/var/lib/docker/overlay2/8b9348a37094a2584ebf50039995a99cbfb574012cbeb5d539aafd97ac640ac1/merged\\\" at \\\"/var/lib/docker/overlay2/8b9348a37094a2584ebf50039995a99cbfb574012cbeb5d539aafd97ac640ac1/merged/srv/db\\\" caused \\\"mkdir /var/lib/docker/overlay2/8b9348a37094a2584ebf50039995a99cbfb574012cbeb5d539aafd97ac640ac1/merged/srv/db: permission denied\\\"\"": unknown

ERROR: for db  Cannot start service db: OCI runtime create failed: container_linux.go:346: starting container process caused "process_linux.go:449: container init caused \"rootfs_linux.go:58: mounting \\\"/Users/serban/Projects/OCHA/HPC/hid_api/db\\\" to rootfs \\\"/var/lib/docker/overlay2/8b9348a37094a2584ebf50039995a99cbfb574012cbeb5d539aafd97ac640ac1/merged\\\" at \\\"/var/lib/docker/overlay2/8b9348a37094a2584ebf50039995a99cbfb574012cbeb5d539aafd97ac640ac1/merged/srv/db\\\" caused \\\"mkdir /var/lib/docker/overlay2/8b9348a37094a2584ebf50039995a99cbfb574012cbeb5d539aafd97ac640ac1/merged/srv/db: permission denied\\\"\"": unknown
```
PS: we dont care about travis.
