### PR TITLE
HID-1967: enforce policy that new password cannot match old password

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -889,7 +889,7 @@ module.exports = {
     if (!HelperService.isAuthorizedUrl(appValidationUrl)) {
       logger.warn(
         `[UserController->validateEmail] app_validation_url ${appValidationUrl} is not in authorizedDomains allowlist`,
-        { security: true, fail: true, request },
+        { request, security: true, fail: true },
       );
       throw Boom.badRequest('Invalid app_validation_url');
     }
@@ -950,12 +950,12 @@ module.exports = {
       await user.save();
       logger.info(
         `[UserController->updatePassword] Successfully updated password for user ${user._id.toString()}`,
-        { security: true },
+        { request, security: true },
       );
     } else {
       logger.warn(
         `[UserController->updatePassword] Could not update password for user ${user._id.toString()}. Old password is wrong`,
-        { security: true, fail: true },
+        { request, security: true, fail: true },
       );
       throw Boom.badRequest('The old password is wrong');
     }
@@ -969,7 +969,7 @@ module.exports = {
       if (!HelperService.isAuthorizedUrl(appResetUrl)) {
         logger.warn(
           `[UserController->resetPasswordEndpoint] app_reset_url ${appResetUrl} is not in authorizedDomains allowlist`,
-          { security: true, fail: true, request },
+          { request, security: true, fail: true },
         );
         throw Boom.badRequest('app_reset_url is invalid');
       }
@@ -983,6 +983,7 @@ module.exports = {
       await EmailService.sendResetPassword(record, appResetUrl);
       logger.info(
         `[UserController->resetPasswordEndpoint] Successfully sent reset password email to ${record.email}`,
+        { request, security: true },
       );
       return '';
     }
@@ -991,6 +992,7 @@ module.exports = {
       || !request.payload.id || !request.payload.time) {
       logger.warn(
         '[UserController->resetPasswordEndpoint] Wrong or missing arguments',
+        { request, security: true }
       );
       throw Boom.badRequest('Wrong arguments');
     }
@@ -998,7 +1000,7 @@ module.exports = {
     if (!User.isStrongPassword(request.payload.password)) {
       logger.warn(
         '[UserController->resetPasswordEndpoint] Could not reset password. New password is not strong enough.',
-        { security: true, fail: true, request },
+        { request, security: true, fail: true },
       );
       throw Boom.badRequest('New password is not strong enough');
     }
@@ -1007,7 +1009,7 @@ module.exports = {
     if (!record) {
       logger.warn(
         `[UserController->resetPasswordEndpoint] Could not reset password. User ${request.payload.id} not found`,
-        { security: true, fail: true, request },
+        { request, security: true, fail: true },
       );
       throw Boom.badRequest('Reset password link is expired or invalid');
     }
@@ -1022,6 +1024,7 @@ module.exports = {
       if (pwd === record.password) {
         logger.warn(
           `[UserController->resetPasswordEndpoint] Could not reset password for user ${request.payload.id}. The new password can not be the same as the old one`,
+          { request, security: true, fail: true },
         );
         throw Boom.badRequest('The new password can not be the same as the old one');
       } else {
@@ -1032,6 +1035,7 @@ module.exports = {
     } else {
       logger.warn(
         '[UserController->resetPasswordEndpoint] Reset password link is expired or invalid',
+        { request, security: true, fail: true },
       );
       throw Boom.badRequest('Reset password link is expired or invalid');
     }
@@ -1064,7 +1068,7 @@ module.exports = {
     await record.save();
     logger.info(
       `[UserController->resetPasswordEndpoint] Password updated successfully for user ${record._id.toString()}`,
-      { security: true, request },
+      { request, security: true },
     );
     return 'Password reset successfully';
   },

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1026,7 +1026,7 @@ module.exports = {
           `[UserController->resetPasswordEndpoint] Could not reset password for user ${request.payload.id}. The new password can not be the same as the old one`,
           { request, security: true, fail: true },
         );
-        throw Boom.badRequest('The new password can not be the same as the old one');
+        throw Boom.badRequest('Could not reset password');
       } else {
         record.password = User.hashPassword(request.payload.password);
         record.verifyEmail(record.email);

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -544,6 +544,17 @@ module.exports = {
         `[UserController->update] Updating user password for user ${user.id}`,
         { security: true },
       );
+
+      // Check to see if new password matches current (old) password.
+      if (request.payload.old_password === request.payload.new_password) {
+        logger.warn(
+          `[UserController->update] Could not update user password for user ${user.id}. New password is the same as old password`,
+          { request, security: true, fail: true },
+        );
+        throw Boom.badRequest('New password must be different than previous password');
+      }
+
+      // Check old password before continuing. It must be correct to proceed.
       if (user.validPassword(request.payload.old_password)) {
         if (!User.isStrongPassword(request.payload.new_password)) {
           logger.warn(

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -992,7 +992,7 @@ module.exports = {
       || !request.payload.id || !request.payload.time) {
       logger.warn(
         '[UserController->resetPasswordEndpoint] Wrong or missing arguments',
-        { request, security: true }
+        { request, security: true },
       );
       throw Boom.badRequest('Wrong arguments');
     }

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1020,15 +1020,15 @@ module.exports = {
     }
     let domain = null;
     if (record.validHash(request.payload.hash, 'reset_password', request.payload.time) === true) {
-      const pwd = User.hashPassword(request.payload.password);
-      if (pwd === record.password) {
+      // Check the new password against the old one.
+      if (record.validPassword(request.payload.password)) {
         logger.warn(
           `[UserController->resetPasswordEndpoint] Could not reset password for user ${request.payload.id}. The new password can not be the same as the old one`,
           { request, security: true, fail: true },
         );
         throw Boom.badRequest('The new password can not be the same as the old one');
       } else {
-        record.password = pwd;
+        record.password = User.hashPassword(request.payload.password);
         record.verifyEmail(record.email);
         domain = await record.isVerifiableEmail(record.email);
       }

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -912,6 +912,14 @@ module.exports = {
       throw Boom.badRequest('Request is missing parameters (old or new password)');
     }
 
+    if (request.payload.old_password === request.payload.new_password) {
+      logger.warn(
+        `[UserController->update] Could not update user password for user ${user.id}. New password is the same as old password`,
+        { request, security: true, fail: true },
+      );
+      throw Boom.badRequest('New password must be different than previous password');
+    }
+
     if (!User.isStrongPassword(request.payload.new_password)) {
       logger.warn(
         '[UserController->updatePassword] New password is not strong enough',


### PR DESCRIPTION
# HID-1967

While working on HID-2002 I noticed it is possible to craft an API request that "changes" your new password to the current password. All copy on our site/api-docs implies this is not possible. Small conditional is all we needed.