### PR TITLE
HID-2008: include plaintext URL when sending TOTP config

### DIFF
--- a/api/controllers/TOTPController.js
+++ b/api/controllers/TOTPController.js
@@ -36,7 +36,10 @@ module.exports = {
     }
     const otpauthUrl = authenticator.generateTotpUri(secret, user.name, qrCodeName, 'SHA1', 6, 30);
     const qrcode = await QRCode.toDataURL(otpauthUrl);
-    return { url: qrcode };
+    return {
+      url: qrcode,
+      raw: otpauthUrl,
+    };
   },
 
   // Empty endpoint to verify a TOTP token


### PR DESCRIPTION
# HID-2008

As simple as expected :) We should offer clients the ability to print the config and allow a user to copy/paste. There is no change to our security by offering this option, since QR codes are also plaintext (in a manner of speaking).

Obviously this PR might bring to attention the poor naming convention currently used by the API, but for backwards-compat I don't want to change the existing property name without exposing a V3 route that declares the breaking change.

If we did offer a V3, I'd probably reshape the object to be:

```js
{
  url: otpauthUrl,
  qrcode: qrcode,
}
```