### PR TITLE
HID-2021 / HID-2022: emails to notify auth/profile users about decommissioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8.11.3"
+  - "10.14.2"
 
 services:
   - mongodb

--- a/api/services/EmailService.js
+++ b/api/services/EmailService.js
@@ -133,6 +133,30 @@ module.exports = {
     return send(mailOptions, 'reset_password', context);
   },
 
+  sendDecommissionForAuthUsers(user) {
+    const mailOptions = {
+      to: user.email,
+      locale: user.locale,
+    };
+    const context = {
+      name: user.name,
+    };
+    logger.info(`[EmailService->sendDecommissionForAuthUsers]`, context);
+    return send(mailOptions, 'decommission_auth', context);
+  },
+
+  sendDecommissionForProfileUsers(user) {
+    const mailOptions = {
+      to: user.email,
+      locale: user.locale,
+    };
+    const context = {
+      name: user.name,
+    };
+    logger.info(`[EmailService->sendDecommissionForProfileUsers]`, context);
+    return send(mailOptions, 'decommission_profile', context);
+  },
+
   sendForcedPasswordReset(user) {
     const mailOptions = {
       to: user.email,

--- a/commands/decommissionEmailsAuth.js
+++ b/commands/decommissionEmailsAuth.js
@@ -1,0 +1,42 @@
+/* eslint no-await-in-loop: "off", no-restricted-syntax: "off", no-console: "off" */
+/* eslint func-names: "off" */
+/**
+ * @module decommissionEmailsAuth
+ *
+ * @description Sends an email to AUTH users notifying them that HIDv2 is
+ * being decommissioned in January 2021.
+ */
+const { argv } = require('yargs');
+const mongoose = require('mongoose');
+const app = require('../');
+
+const store = app.config.env[process.env.NODE_ENV].database.stores[process.env.NODE_ENV];
+mongoose.connect(store.uri, store.options);
+
+const User = require('../api/models/User');
+const EmailService = require('../api/services/EmailService');
+
+async function run() {
+  const limit = argv.limit || 0;
+
+  const cursor = User
+    .find({ authOnly: true })
+    .limit(limit)
+    .cursor({ noCursorTimeout: true });
+
+  // Send one email to each user we queried.
+  for (let user = await cursor.next(); user !== null; user = await cursor.next()) {
+    await EmailService.sendDecommissionForProfileUsers(user);
+  }
+
+  // When we are done queing emails, exit with status 0.
+  process.exit();
+}
+
+(async function () {
+  await run();
+}()).catch((e) => {
+  // If we catch any errors, print them and exit with status 1.
+  console.log(e);
+  process.exit(1);
+});

--- a/commands/decommissionEmailsProfile.js
+++ b/commands/decommissionEmailsProfile.js
@@ -1,0 +1,42 @@
+/* eslint no-await-in-loop: "off", no-restricted-syntax: "off", no-console: "off" */
+/* eslint func-names: "off" */
+/**
+ * @module decommissionEmailsProfile
+ *
+ * @description Sends an email to PROFILE users notifying them that HIDv2 is
+ * being decommissioned in January 2021.
+ */
+const { argv } = require('yargs');
+const mongoose = require('mongoose');
+const app = require('../');
+
+const store = app.config.env[process.env.NODE_ENV].database.stores[process.env.NODE_ENV];
+mongoose.connect(store.uri, store.options);
+
+const User = require('../api/models/User');
+const EmailService = require('../api/services/EmailService');
+
+async function run() {
+  const limit = argv.limit || 0;
+
+  const cursor = User
+    .find({ authOnly: false }) // not authOnly = profile
+    .limit(limit)
+    .cursor({ noCursorTimeout: true });
+
+  // Send one email to each user we queried.
+  for (let user = await cursor.next(); user !== null; user = await cursor.next()) {
+    await EmailService.sendDecommissionForProfileUsers(user);
+  }
+
+  // When we are done queing emails, exit with status 0.
+  process.exit();
+}
+
+(async function () {
+  await run();
+}()).catch((e) => {
+  // If we catch any errors, print them and exit with status 1.
+  console.log(e);
+  process.exit(1);
+});

--- a/emails/decommission_auth/fr/html.ejs
+++ b/emails/decommission_auth/fr/html.ejs
@@ -1,0 +1,9 @@
+<p>Cher/chère <%= user.name %>,</p>
+
+<p>En tant qu'utilisateur du service d'authentification de Humanitarian ID (HID login), vous savez peut-être que les fonctionnalités de gestion des listes de contacts de HID seront mises hors service en janvier 2021.</p>
+<p>Nous tenons à souligner que ces modifications n'affecteront PAS le service d'authentification et votre capacité à accéder à toutes <a href="https://about.humanitarian.id/partners-using-our-authentication-service">les plates-formes intégrées</a> avec HID à l'aide de vos informations d'identification actuelles.</p>
+<p>Aucune autre action n'est requise de votre part, mais si vous avez des questions sur ces changements ou si vous avez besoin d'assistance, contactez-nous à info@humanitarian.id.</p>
+<br>
+<p>Bien cordialement,</p>
+
+<% include ../../includes/footer_fr %>

--- a/emails/decommission_auth/fr/html.ejs
+++ b/emails/decommission_auth/fr/html.ejs
@@ -1,7 +1,7 @@
 <p>Cher/chère <%= user.name %>,</p>
 
 <p>En tant qu'utilisateur du service d'authentification de Humanitarian ID (HID login), vous savez peut-être que les fonctionnalités de gestion des listes de contacts de HID seront mises hors service en janvier 2021.</p>
-<p>Nous tenons à souligner que ces modifications n'affecteront PAS le service d'authentification et votre capacité à accéder à toutes <a href="https://about.humanitarian.id/partners-using-our-authentication-service">les plates-formes intégrées</a> avec HID à l'aide de vos informations d'identification actuelles.</p>
+<p>Nous tenons à souligner que ces modifications n'affecteront PAS le service d'authentification et votre capacité à accéder à toutes <a href="https://about.humanitarian.id/partners-using-our-authentication-service">les plateformes intégrées</a> avec HID à l'aide de vos informations d'identification actuelles.</p>
 <p>Aucune autre action n'est requise de votre part, mais si vous avez des questions sur ces changements ou si vous avez besoin d'assistance, contactez-nous à info@humanitarian.id.</p>
 <br>
 <p>Bien cordialement,</p>

--- a/emails/decommission_auth/fr/subject.ejs
+++ b/emails/decommission_auth/fr/subject.ejs
@@ -1,0 +1,1 @@
+Sujet du courrier électronique en français

--- a/emails/decommission_auth/fr/subject.ejs
+++ b/emails/decommission_auth/fr/subject.ejs
@@ -1,1 +1,1 @@
-Sujet du courrier électronique en français
+Mise à jour sur les fonctionnalités de gestion des contacts de Humanitarian ID

--- a/emails/decommission_auth/html.ejs
+++ b/emails/decommission_auth/html.ejs
@@ -1,0 +1,9 @@
+<p>Dear <%= user.name %>,</p>
+
+<p>As a user of Humanitarian ID Authentication (HID login) service you may be aware that contact list management features of HID will be decommissioned in January 2021.</p>
+<p>We would like to underline that these changes will NOT affect the authentication service and your ability to access all HID <a href="https://about.humanitarian.id/partners-using-our-authentication-service">integrated platforms</a> using your current credentials.</p>
+<p>No further action is required from you, however if you have any questions on these changes or require support please reach out to us at info@humanitarian.id.</p>
+<br>
+<p>Kind regards,</p>
+
+<% include ../includes/footer_en %>

--- a/emails/decommission_auth/subject.ejs
+++ b/emails/decommission_auth/subject.ejs
@@ -1,0 +1,1 @@
+English subject line

--- a/emails/decommission_auth/subject.ejs
+++ b/emails/decommission_auth/subject.ejs
@@ -1,1 +1,1 @@
-English subject line
+Update on Contacts Management Features of Humanitarian ID

--- a/emails/decommission_profile/fr/html.ejs
+++ b/emails/decommission_profile/fr/html.ejs
@@ -1,0 +1,10 @@
+<p>Cher/chère <%= user.name %>,</p>
+
+<p>Merci d'être membre de Humanitarian ID.</p>
+<p>Nous vous informons que les fonctionnalités de gestion des contacts de HID seront mises hors service en janvier 2021, conformément à son cadre technologique <a href="https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c">en fin de vie</a>. Veuillez noter que vous pouvez continuer à utiliser la plateforme jusqu'à cette date, mais nous vous recommandons <a href="https://docs.google.com/document/d/14x-wL1Yr0Il4gKgVuMxlP3GnaVyanS-QFhgUcCe1M50/edit?usp=sharing">d'exporter tous les contacts et listes</a> pertinents à l'avance.</p>
+<p>Veuillez noter que cela <strong>n'affectera PAS le service d'authentification HID</strong> (HID login) qui restera fonctionnel et vous pourrez continuer à accéder <a href="https://about.humanitarian.id/partners-using-our-authentication-service">aux plates-formes intégrées</a> avec HID à l'aide de vos informations d'identification actuelles.</p>
+<p>Si vous avez des questions sur ces changements ou avez besoin d'assistance, contactez-nous à info@humanitarian.id.</p>
+<br>
+<p>Bien cordialement,</p>
+
+<% include ../../includes/footer_fr %>

--- a/emails/decommission_profile/fr/html.ejs
+++ b/emails/decommission_profile/fr/html.ejs
@@ -1,8 +1,8 @@
 <p>Cher/chère <%= user.name %>,</p>
 
 <p>Merci d'être membre de Humanitarian ID.</p>
-<p>Nous vous informons que les fonctionnalités de gestion des contacts de HID seront mises hors service en janvier 2021, conformément à son cadre technologique <a href="https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c">en fin de vie</a>. Veuillez noter que vous pouvez continuer à utiliser la plateforme jusqu'à cette date, mais nous vous recommandons <a href="https://docs.google.com/document/d/14x-wL1Yr0Il4gKgVuMxlP3GnaVyanS-QFhgUcCe1M50/edit?usp=sharing">d'exporter tous les contacts et listes</a> pertinents à l'avance.</p>
-<p>Veuillez noter que cela <strong>n'affectera PAS le service d'authentification HID</strong> (HID login) qui restera fonctionnel et vous pourrez continuer à accéder <a href="https://about.humanitarian.id/partners-using-our-authentication-service">aux plates-formes intégrées</a> avec HID à l'aide de vos informations d'identification actuelles.</p>
+<p>Nous vous informons que les fonctionnalités de gestion des contacts de HID seront mises hors service en janvier 2021, conformément à son cadre technologique <a href="https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c">en raison de la fin de vie de sa base technologique</a>. Veuillez noter que vous pouvez continuer à utiliser la plateforme jusqu'à cette date, mais nous vous recommandons <a href="https://docs.google.com/document/d/14x-wL1Yr0Il4gKgVuMxlP3GnaVyanS-QFhgUcCe1M50/edit?usp=sharing">d'exporter tous les contacts et listes</a> pertinents à l'avance.</p>
+<p>Veuillez noter que cela <strong>n'affectera PAS le service d'authentification HID</strong> (HID login) qui restera fonctionnel et vous pourrez continuer à accéder <a href="https://about.humanitarian.id/partners-using-our-authentication-service">aux plateformes intégrées</a> avec HID à l'aide de vos informations d'identification actuelles.</p>
 <p>Si vous avez des questions sur ces changements ou avez besoin d'assistance, contactez-nous à info@humanitarian.id.</p>
 <br>
 <p>Bien cordialement,</p>

--- a/emails/decommission_profile/fr/subject.ejs
+++ b/emails/decommission_profile/fr/subject.ejs
@@ -1,0 +1,1 @@
+Sujet du courrier électronique en français

--- a/emails/decommission_profile/fr/subject.ejs
+++ b/emails/decommission_profile/fr/subject.ejs
@@ -1,1 +1,1 @@
-Sujet du courrier électronique en français
+Mise hors service des fonctionnalités de gestion des contacts de Humanitarian ID

--- a/emails/decommission_profile/html.ejs
+++ b/emails/decommission_profile/html.ejs
@@ -1,0 +1,10 @@
+<p>Dear <%= user.name %>,</p>
+
+<p>Thank you for being a member of Humanitarian ID.</p>
+<p>We would like to inform you that the contact management features of HID will be decommissioned in January 2021, in line with its technology framework approaching <a href="https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c">end-of-life</a>. Please note that you can continue using the platform until this date, however we recommend that you <a href="https://docs.google.com/document/d/14x-wL1Yr0Il4gKgVuMxlP3GnaVyanS-QFhgUcCe1M50/edit?usp=sharing">export any relevant contacts and lists</a> from the platform before then.</p>
+<p>Please note that this <strong>will NOT affect the HID Authentication service</strong> (HID login) which will remain functional and you will continue to be able to access HID’s <a href="https://about.humanitarian.id/partners-using-our-authentication-service">integrated platforms</a> using your current credentials.</p>
+<p>If you have any questions on these changes or require support please reach out to us at info@humanitarian.id.</p>
+<br>
+<p>Kind regards,</p>
+
+<% include ../includes/footer_en %>

--- a/emails/decommission_profile/subject.ejs
+++ b/emails/decommission_profile/subject.ejs
@@ -1,1 +1,1 @@
-English subject line
+Decommissioning the Humanitarian ID Contact Service

--- a/emails/decommission_profile/subject.ejs
+++ b/emails/decommission_profile/subject.ejs
@@ -1,0 +1,1 @@
+English subject line

--- a/package-lock.json
+++ b/package-lock.json
@@ -5841,9 +5841,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
-      "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+      "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
       "requires": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -5855,7 +5855,7 @@
         "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^16.1.0"
+        "yargs-parser": "^18.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5922,9 +5922,9 @@
           }
         },
         "yargs-parser": {
-          "version": "16.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+          "version": "18.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
+          "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "validator": "^10.11.0",
     "winston": "^2.2",
     "winston-daily-rotate-file": "^1.4.6",
-    "yargs": "^15.1.0"
+    "yargs": "^15.3.1"
   },
   "devDependencies": {
     "acorn": "^5.7.4",


### PR DESCRIPTION
# HID-2021 + HID-2022

Two new emails to notify users about HID v2 decommissioning. There are separate emails for profile and auth users.

Bonus perk of @orakili reviewing is he can spot all the french typos I probably made 😆 

Email subject lines for both EN/FR pending