### PR TITLE
HID-2035: allow picture uploads to AWS/local environments

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -352,7 +352,16 @@ const UserSchema = new Schema({
     validate: validate({
       validator: 'isURL',
       passIfEmpty: true,
-      arguments: { host_whitelist: ['api.humanitarian.id', 'api.dev.humanitarian.id', 'api.staging.humanitarian.id'] },
+      arguments: {
+        host_whitelist: [
+          'api.humanitarian.id',
+          'api.dev.humanitarian.id',
+          'api.staging.humanitarian.id',
+          'dev.api-humanitarian-id.ahconu.org',
+          'stage.api-humanitarian-id.ahconu.org',
+          'api.hid.vm',
+        ],
+      },
       message: 'picture should be a valid URL',
     }),
     default: '',


### PR DESCRIPTION
# HID-2035

We couldn't upload photos on AWS domains. This band-aids a fix.

Updated the list of TODOs in HID-1894 to include this list.