### PR TITLE
HID-1967: update password strength checks

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -270,6 +270,17 @@ module.exports = [
   },
 
   {
+    method: 'POST',
+    path: '/api/v3/user',
+    options: {
+      pre: [
+        UserPolicy.canCreate,
+      ],
+      handler: UserController.create,
+    },
+  },
+
+  {
     method: 'GET',
     path: '/api/v2/user/{id?}',
     handler: UserController.find,


### PR DESCRIPTION
# HID-1967

Following up on #86 and UN-OCHA/hid_app2#209

This branch removes any user's ability to reset passwords using generic `PUT`s to the API. In previous PRs we agreed that the work to adopt v3 password complexity requirements was unfinished; I believe this PR addresses all previous issues.

What remains in the API is the `/user/:id/password` for both v2/v3. Every time the strength check is invoked, it is done so by first looking whether v2 or v3 was called, and it checks strength based on that. When we deprecate/remove v2, we can simplify all of this, but for now it meets our goals without disrupting existing functionality.

Although this is technically a breaking change, the only client of concern is the AngularJS codebase, which I already patched up and deployed to dev:

- AngularJS app is already using the correct method on dev.
- HIDv3 is unreleased, but also using the correct method.
