### PR TITLE
HID-2038: remove emails using dedicated method

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1221,7 +1221,7 @@ module.exports = {
   },
 
   async dropEmail(request) {
-    const userId = request.params.id;
+    const { id, email } = request.params;
 
     if (!request.params.email) {
       logger.warn(
@@ -1230,17 +1230,16 @@ module.exports = {
       throw Boom.badRequest();
     }
 
-    const record = await User.findOne({ _id: userId });
+    const record = await User.findOne({ _id: id });
     if (!record) {
       logger.warn(
-        `[UserController->dropEmail] User ${userId} not found`,
+        `[UserController->dropEmail] User ${id} not found`,
       );
       throw Boom.notFound();
     }
-    const { email } = request.params;
     if (email === record.email) {
       logger.warn(
-        `[UserController->dropEmail] Primary email for user ${userId} can not be removed`,
+        `[UserController->dropEmail] Primary email for user ${id} can not be removed`,
       );
       throw Boom.badRequest('You can not remove the primary email');
     }
@@ -1258,10 +1257,11 @@ module.exports = {
       record.verified = false;
     }
     await record.save();
+
     logger.info(
-      `[UserController->dropEmail] User ${record.id} saved successfully`,
+      `[UserController->dropEmail] User ${id} saved successfully`,
     );
-    // await OutlookService.synchronizeUser(record);
+
     return record;
   },
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -543,6 +543,7 @@ module.exports = [
       validate: {
         params: Joi.object({
           id: Joi.string().regex(objectIdRegex),
+          email: Joi.string().email({ minDomainSegments: 2 }),
         }),
       },
     },

--- a/config/routes.js
+++ b/config/routes.js
@@ -550,6 +550,23 @@ module.exports = [
   },
 
   {
+    method: 'DELETE',
+    path: '/api/v3/user/{id}/emails/{email}',
+    options: {
+      pre: [
+        UserPolicy.canUpdate,
+      ],
+      handler: UserController.dropEmail,
+      validate: {
+        params: Joi.object({
+          id: Joi.string().regex(objectIdRegex),
+          email: Joi.string().email({ minDomainSegments: 2 }),
+        }),
+      },
+    },
+  },
+
+  {
     method: 'POST',
     path: '/api/v2/user/{id}/phone_numbers',
     options: {


### PR DESCRIPTION
# HID-2038

I uncovered this while doing something else but it's worth tending to. This allows us to fix up yet another instance of our clients using generic `PUT`s to do destructive operations.

The substantive change is the addition of parameter validation. The method could not function before, because the parameter was named but not validated.