### PR TITLE
HID-2022: frenchity-french emails cannot be frenchity found

### DIFF
--- a/commands/decommissionEmailsAuth.js
+++ b/commands/decommissionEmailsAuth.js
@@ -18,9 +18,10 @@ const EmailService = require('../api/services/EmailService');
 
 async function run() {
   const limit = argv.limit || 0;
+  const locale = argv.locale || /.*/;
 
   const cursor = User
-    .find({ authOnly: true })
+    .find({ authOnly: true, locale })
     .limit(limit)
     .cursor({ noCursorTimeout: true });
 


### PR DESCRIPTION
# HID-2022

To enable QA, I added a new `locale` argument to our Jenkins job. This PR allows us to use it on Jenkins.

Note: the corresponding prod job does NOT have such an argument so I checked on my local (and will try again in Jenkins on dev) that omitting the arg has the intended effect.