### PR TITLE
HID-2026: apply standard settings to local environment

### DIFF
--- a/config/env/local.js
+++ b/config/env/local.js
@@ -9,7 +9,11 @@ module.exports = {
       local: {
         migrate: 'create',
         uri: 'mongodb://db:27017/local',
-        options: {},
+        options: {
+          keepAlive: 600000,
+          connectTimeoutMS: 60000,
+          useNewUrlParser: true,
+        },
       },
     },
     models: {


### PR DESCRIPTION
# HID-2026

PR smaller than I expected. I always see an error in my console when booting and thought it must apply to all environments, but it ended up being local only.

```
api_1  | (node:454) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.
```

Anyway, it's fixed.
