### PR TITLE
HID-2052: Swagger inline

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -589,24 +589,10 @@ module.exports = {
    *   '200':
    *     description: JWT was successfully blacklisted
    *   '400':
+   *     description: Missing token
+   *   '403':
    *     description: Could not blacklist this token because you did not generate it
    */
-  //
-  // TODO: The following error is also a possible outcome of the blacklist
-  //       operation, but Swagger intentionally avoids a way of specifying more
-  //       than one response message for a specific HTTP status code. In the mean
-  //       time here is the YML we would have in the above definition if it were
-  //       possible to compile.
-  //
-  // *   400:
-  // *     description: Missing token
-  //
-  //       One possible solution would be to issue HTTP 403 when the token
-  //       did not belong to the user making the request. It is specifically a
-  //       matter of perms/authorization so it seems to fit.
-  //
-  // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
-  //
   async blacklistJwt(request) {
     const token = request.payload ? request.payload.token : null;
     if (!token) {
@@ -633,7 +619,7 @@ module.exports = {
       '[AuthController->blacklistJwt] Tried to blacklist a token by a user who does not have the permission',
       { security: true, fail: true, request },
     );
-    throw Boom.badRequest('Could not blacklist this token because you did not generate it');
+    throw Boom.forbidden('Could not blacklist this token because you did not generate it');
   },
 
   /**

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -116,13 +116,13 @@ module.exports = {
    * tags:
    *   - auth
    * summary: 'Generate a jsonwebtoken'
-   * parameters:
-   *   - name: 'body'
-   *     description: 'User email'
-   *     in: body
-   *     required: true
-   *     schema:
-   *       $ref: '#/definitions/Auth'
+   * requestBody:
+   *   description: 'User email and password'
+   *   required: true
+   *   content:
+   *     application/json:
+   *       schema:
+   *         $ref: '#/components/schemas/Auth'
    * responses:
    *   '200':
    *     description: 'The json web token'

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -564,13 +564,49 @@ module.exports = {
     return out;
   },
 
-  // Provides a list of the json web tokens with no expiration date created by the current user
+  /*
+   * @api [get] /jsonwebtoken
+   *
+   * tags:
+   *   - auth
+   * summary: Retrieve the JWTs of the current user
+   * responses:
+   *   '200':
+   *     description: List of the JWTs of the current user
+   */
   async jwtTokens(request) {
     const tokens = await JwtToken.find({ user: request.auth.credentials._id });
     return tokens;
   },
 
-  // Blacklist a JSON Web Token
+  /*
+   * @api [delete] /jsonwebtoken
+   *
+   * tags:
+   *   - auth
+   * summary: Blacklists a JWT for the current user
+   * responses:
+   *   '200':
+   *     description: JWT was successfully blacklisted
+   *   '400':
+   *     description: Could not blacklist this token because you did not generate it
+   */
+  //
+  // TODO: The following error is also a possible outcome of the blacklist
+  //       operation, but Swagger intentionally avoids a way of specifying more
+  //       than one response message for a specific HTTP status code. In the mean
+  //       time here is the YML we would have in the above definition if it were
+  //       possible to compile.
+  //
+  // *   400:
+  // *     description: Missing token
+  //
+  //       One possible solution would be to issue HTTP 403 when the token
+  //       did not belong to the user making the request. It is specifically a
+  //       matter of perms/authorization so it seems to fit.
+  //
+  // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+  //
   async blacklistJwt(request) {
     const token = request.payload ? request.payload.token : null;
     if (!token) {

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -111,8 +111,29 @@ function loginRedirect(request, reply, cookie = false) {
 }
 
 module.exports = {
-  /**
-   * Authenticate user through JWT
+  /*
+   * @api [post] /jsonwebtoken
+   * tags:
+   *   - auth
+   * summary: 'Generate a jsonwebtoken'
+   * parameters:
+   *   - name: 'body'
+   *     description: 'User email'
+   *     in: body
+   *     required: true
+   *     schema:
+   *       $ref: '#/definitions/Auth'
+   * responses:
+   *   '200':
+   *     description: 'The json web token'
+   *   '400':
+   *     description: 'Bad request. Missing email and/or password'
+   *   '401':
+   *     description: 'Wrong email and/or password'
+   *   '429':
+   *     description: >-
+   *       The account was locked for 5 minutes because there were more than 5
+   *       unsuccessful login attempts within the last 5 minutes
    */
   async authenticate(request) {
     const result = await loginHelper(request);

--- a/docs/v3/hid.yml
+++ b/docs/v3/hid.yml
@@ -1,0 +1,41 @@
+openapi: 3.0.3
+x-api-id: hid-api
+info:
+  version: 3.0.0-dev
+  title: HID API
+  license:
+    name: Apache-2.0
+host: api.humanitarian.id
+basePath: /api/v3
+schemes:
+  - https
+servers:
+  - url: 'https://api.humanitarian.id/api/v3'
+    description: Production server. For use by HID Integration Partners.
+  - url: 'https://dev.api-humanitarian-id.ahconu.org/api/v3'
+    description: Dev server. For use by UNOCHA developers.
+paths:
+  /jsonwebtoken:
+    post:
+      tags:
+        - auth
+      summary: Generate a jsonwebtoken
+      parameters:
+        - name: body
+          description: User email
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Auth'
+      responses:
+        '200':
+          description: The json web token
+        '400':
+          description: Bad request. Missing email and/or password
+        '401':
+          description: Wrong email and/or password
+        '429':
+          description: >-
+            The account was locked for 5 minutes because there were more than 5
+            unsuccessful login attempts within the last 5 minutes
+

--- a/docs/v3/hid.yml
+++ b/docs/v3/hid.yml
@@ -38,4 +38,20 @@ paths:
           description: >-
             The account was locked for 5 minutes because there were more than 5
             unsuccessful login attempts within the last 5 minutes
+    get:
+      tags:
+        - auth
+      summary: Retrieve the JWTs of the current user
+      responses:
+        '200':
+          description: List of the JWTs of the current user
+    delete:
+      tags:
+        - auth
+      summary: Blacklists a JWT for the current user
+      responses:
+        '200':
+          description: JWT was successfully blacklisted
+        '400':
+          description: Could not blacklist this token because you did not generate it
 

--- a/docs/v3/hid.yml
+++ b/docs/v3/hid.yml
@@ -14,6 +14,23 @@ servers:
     description: Production server. For use by HID Integration Partners.
   - url: 'https://dev.api-humanitarian-id.ahconu.org/api/v3'
     description: Dev server. For use by UNOCHA developers.
+tags:
+  - name: user
+    description: User related operations
+  - name: auth
+    description: Authentication related methods
+  - name: list
+    description: List related methods
+  - name: connection
+    description: Methods related to user connections
+  - name: service
+    description: 'Methods related to services (mailchimp, googlegroup)'
+  - name: client
+    description: Methods related to oauth clients
+  - name: notification
+    description: Methods related to notifications
+  - name: totp
+    description: Methods related to 2 Factor Authentication
 paths:
   /jsonwebtoken:
     post:

--- a/docs/v3/hid.yml
+++ b/docs/v3/hid.yml
@@ -5,10 +5,6 @@ info:
   title: HID API
   license:
     name: Apache-2.0
-host: api.humanitarian.id
-basePath: /api/v3
-schemes:
-  - https
 servers:
   - url: 'https://api.humanitarian.id/api/v3'
     description: Production server. For use by HID Integration Partners.
@@ -16,11 +12,11 @@ servers:
     description: Dev server. For use by UNOCHA developers.
 tags:
   - name: user
-    description: User related operations
+    description: Methods related to users
   - name: auth
-    description: Authentication related methods
+    description: Methods related to authentication
   - name: list
-    description: List related methods
+    description: Methods related to lists
   - name: connection
     description: Methods related to user connections
   - name: service
@@ -30,20 +26,31 @@ tags:
   - name: notification
     description: Methods related to notifications
   - name: totp
-    description: Methods related to 2 Factor Authentication
+    description: Methods related to 2-factor authentication
+components:
+  schemas:
+    Auth:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          format: password
 paths:
   /jsonwebtoken:
     post:
       tags:
         - auth
       summary: Generate a jsonwebtoken
-      parameters:
-        - name: body
-          description: User email
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/Auth'
+      requestBody:
+        description: User email and password
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Auth'
       responses:
         '200':
           description: The json web token
@@ -70,5 +77,7 @@ paths:
         '200':
           description: JWT was successfully blacklisted
         '400':
+          description: Missing token
+        '403':
           description: Could not blacklist this token because you did not generate it
 

--- a/docs/v3/swaggerBase.yaml
+++ b/docs/v3/swaggerBase.yaml
@@ -5,10 +5,6 @@ info:
   title: HID API
   license:
     name: Apache-2.0
-host: api.humanitarian.id
-basePath: /api/v3
-schemes:
-  - https
 
 servers:
   - url: 'https://api.humanitarian.id/api/v3'
@@ -33,3 +29,15 @@ tags:
     description: 'Methods related to notifications'
   - name: 'totp'
     description: 'Methods related to 2-factor authentication'
+
+components:
+  schemas:
+    Auth:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          format: password

--- a/docs/v3/swaggerBase.yaml
+++ b/docs/v3/swaggerBase.yaml
@@ -1,16 +1,16 @@
 openapi: 3.0.3
-x-api-id: "hid-api"
+x-api-id: hid-api
 info:
   version: 3.0.0-dev
-  title: "HID API"
+  title: HID API
   license:
-    name: "Apache-2.0"
+    name: Apache-2.0
 host: api.humanitarian.id
 basePath: /api/v3
 schemes:
   - https
 servers:
-  - url: https://api.humanitarian.id/api/v3
+  - url: 'https://api.humanitarian.id/api/v3'
     description: Production server. For use by HID Integration Partners.
-  - url: https://dev.api-humanitarian-id.ahconu.org/api/v3
+  - url: 'https://dev.api-humanitarian-id.ahconu.org/api/v3'
     description: Dev server. For use by UNOCHA developers.

--- a/docs/v3/swaggerBase.yaml
+++ b/docs/v3/swaggerBase.yaml
@@ -9,8 +9,27 @@ host: api.humanitarian.id
 basePath: /api/v3
 schemes:
   - https
+
 servers:
   - url: 'https://api.humanitarian.id/api/v3'
     description: Production server. For use by HID Integration Partners.
   - url: 'https://dev.api-humanitarian-id.ahconu.org/api/v3'
     description: Dev server. For use by UNOCHA developers.
+
+tags:
+  - name: 'user'
+    description: 'Methods related to users'
+  - name: 'auth'
+    description: 'Methods related to authentication'
+  - name: 'list'
+    description: 'Methods related to lists'
+  - name: 'connection'
+    description: 'Methods related to user connections'
+  - name: 'service'
+    description: 'Methods related to services (mailchimp, googlegroup)'
+  - name: 'client'
+    description: 'Methods related to oauth clients'
+  - name: 'notification'
+    description: 'Methods related to notifications'
+  - name: 'totp'
+    description: 'Methods related to 2-factor authentication'

--- a/docs/v3/swaggerBase.yaml
+++ b/docs/v3/swaggerBase.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+x-api-id: "hid-api"
+info:
+  version: 3.0.0-dev
+  title: "HID API"
+  license:
+    name: "Apache-2.0"
+host: api.humanitarian.id
+basePath: /api/v3
+schemes:
+  - https
+servers:
+  - url: https://api.humanitarian.id/api/v3
+    description: Production server. For use by HID Integration Partners.
+  - url: https://dev.api-humanitarian-id.ahconu.org/api/v3
+    description: Dev server. For use by UNOCHA developers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,6 +1349,15 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
+    "comment-patterns": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.10.1.tgz",
+      "integrity": "sha512-fKtMiKJAYvwd66zxY5TwNeqmcAr7N3Xjua5Abcrp1cF7QLk2gT8zi2ZWnvNYDwoKheKwvQUJttpHSgQSODjw+g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3280,6 +3289,12 @@
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
     },
+    "line-counter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/line-counter/-/line-counter-1.1.0.tgz",
+      "integrity": "sha1-EN8sBGrTVG5yT7pV+nLN4YpqAfM=",
+      "dev": true
+    },
     "linkify-it": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
@@ -3758,6 +3773,42 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multi-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/multi-glob/-/multi-glob-1.0.2.tgz",
+      "integrity": "sha512-sUBlFqEARG0FhuI7dELtmLmC+vGHz0supHIMntXazUjzV7hV34dK7LXWtpgD/L29tHsWoui91pLD+vjRnk6PVw==",
+      "dev": true,
+      "requires": {
+        "glob": "5.x"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "multilang-extract-comments": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/multilang-extract-comments/-/multilang-extract-comments-0.3.2.tgz",
+      "integrity": "sha512-H/+eHndsWbGqqQ7FMaYj+1NwFSb0KZFsbWeSGvKz6o1YJMYXFVGLnA6d8f7lSNRQ/wiTLWTmLpOtNyQwaKzgig==",
+      "dev": true,
+      "requires": {
+        "comment-patterns": "^0.10.0",
+        "line-counter": "^1.0.3",
+        "lodash": "^4.17.11",
+        "quotemeta": "0.0.0"
+      }
     },
     "multimatch": {
       "version": "4.0.0",
@@ -4568,6 +4619,12 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
       "integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w=="
     },
+    "quotemeta": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
+      "integrity": "sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w=",
+      "dev": true
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -5167,6 +5224,28 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "swagger-inline": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-3.0.4.tgz",
+      "integrity": "sha512-m3jMsb6Dzr/2EEWFeF8JlDtzqzSrBgcWAJYVzCfUNUWa4nZgfdAeJc0lbpVKL4hL8nZNvIhNM2uJ+MZcF9F1+Q==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.4.1",
+        "commander": "^5.0.0",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.11",
+        "multi-glob": "^1.0.2",
+        "multilang-extract-comments": "^0.3.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        }
       }
     },
     "table": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   "keywords": [],
   "main": "index.js",
   "scripts": {
-    "test": "eslint .",
+    "dev": "node ./node_modules/nodemon/bin/nodemon.js ./server.js",
+    "docs": "swagger-inline './api/**/*' --base 'docs/v3/swaggerBase.yaml' > docs/v3/hid.yml",
     "start": "node ./server.js",
-    "dev": "node ./node_modules/nodemon/bin/nodemon.js ./server.js"
+    "test": "eslint ."
   },
   "dependencies": {
     "@hapi/boom": "^7.4.3",
@@ -72,7 +73,8 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "minimist": "^1.2.5",
-    "nodemon": "^2.0.2"
+    "nodemon": "^2.0.2",
+    "swagger-inline": "^3.0.4"
   },
   "engines": {
     "node": "10.14.2",


### PR DESCRIPTION
# HID-2052

This is the beginning of our effort to maintain API docs for v3. I only documented one method, but it was enough to learn the following about Swagger and the specific tool, `swagger-inline`, that I picked to use going forward:

- Docs can now be placed above each method they describe. I find this far more logical than having them separated in a gigantic YML file in a far-away directory.
- The "base" file is located at `docs/v3/swaggerBase.yaml` and it holds everything not specific to an individual route: Swagger version, API URLs, tags, reusable schemas, etc.
- `docker-compose exec dev npm run docs` will compile the docs to `docs/v3/hid.yml`
- There's an online editor which validates the output YML: https://editor.swagger.io/

Someday I'd love to get the validation running as the docs are generated, but for now they don't. See ticket which summarizes how I ended up with current incomplete approach. IMO this is still a solid start to begin the documentation work.