### PR TITLE
HID-2063: remove direct calls to reply()

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -670,7 +670,7 @@ module.exports = {
       logger.warn(
         '[AuthController->signRequest] Missing url to sign request for file downloads',
       );
-      return reply(Boom.badRequest('Missing url'));
+      throw Boom.badRequest('Missing url');
     }
     const credentials = {
       id: request.auth.credentials._id.toString(),

--- a/api/controllers/ServiceController.js
+++ b/api/controllers/ServiceController.js
@@ -78,7 +78,7 @@ module.exports = {
         logger.warn(
           '[ServiceController->find] Name of a service must have at least 3 characters in find method',
         );
-        return reply(Boom.badRequest('Name must have at least 3 characters'));
+        throw Boom.badRequest('Name must have at least 3 characters');
       }
       criteria.name = criteria.name.replace(/\(|\\|\^|\.|\||\?|\*|\+|\)|\[|\{|<|>|\/|"/, '-');
       criteria.name = new RegExp(criteria.name, 'i');


### PR DESCRIPTION
# HID-2063

My guess is that a previous version of `hapi` used this syntax, and the couple code paths I found are just never used. I know the `signRequest` route is internal to HID so that's why we never see problems from it.

Anyway, they're all squared and throwing normal errors like the rest of the codebase.