### PR TITLE
HID-2048: useUnifiedTopology in mongoose config

### DIFF
--- a/config/env/local.js
+++ b/config/env/local.js
@@ -1,4 +1,5 @@
 
+
 const winston = require('winston');
 const os = require('os');
 const _ = require('lodash');
@@ -13,6 +14,7 @@ module.exports = {
           keepAlive: 600000,
           connectTimeoutMS: 60000,
           useNewUrlParser: true,
+          useUnifiedTopology: true,
         },
       },
     },

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,12 +1,10 @@
 
-
 const winston = require('winston');
 const os = require('os');
 const _ = require('lodash');
 require('winston-daily-rotate-file');
 
 module.exports = {
-
   database: {
     stores: {
       production: {
@@ -16,6 +14,7 @@ module.exports = {
           keepAlive: 600000,
           connectTimeoutMS: 60000,
           useNewUrlParser: true,
+          useUnifiedTopology: true,
         },
       },
     },

--- a/config/env/staging.js
+++ b/config/env/staging.js
@@ -1,5 +1,4 @@
 
-
 const winston = require('winston');
 const os = require('os');
 const _ = require('lodash');
@@ -9,13 +8,13 @@ module.exports = {
   database: {
     stores: {
       staging: {
-        // should be 'create' or 'drop'
         migrate: 'create',
         uri: 'mongodb://db:27017/staging',
         options: {
           keepAlive: 600000,
           connectTimeoutMS: 60000,
           useNewUrlParser: true,
+          useUnifiedTopology: true,
         },
       },
     },

--- a/config/env/testing.js
+++ b/config/env/testing.js
@@ -1,13 +1,6 @@
 
 
 module.exports = {
-
-  trailpack: {
-    disabled: [
-      'repl',
-    ],
-  },
-
   database: {
     stores: {
       testing: {
@@ -17,6 +10,7 @@ module.exports = {
           keepAlive: 600000,
           connectTimeoutMS: 60000,
           useNewUrlParser: true,
+          useUnifiedTopology: true,
         },
       },
     },


### PR DESCRIPTION
# HID-2048

Deprecation warning I see every time the app restarts. The "Server Discovery and Monitoring engine" has been deprecated and will eventually be removed. We can use the new one by supplying a boolean.

There doesn't seem to be any other side effects aside from removing the warning.