### PR TITLE
HID-2078: AuthPolicy.isAdmin can return both 401/403

### DIFF
--- a/api/policies/AuthPolicy.js
+++ b/api/policies/AuthPolicy.js
@@ -89,7 +89,7 @@ module.exports = {
     }
 
     // User authenticated correctly, and has admin permissions.
-    if (request.auth.credentials && request.auth.credentials.is_admin) {
+    if (request.auth.credentials.is_admin) {
       return true;
     }
 


### PR DESCRIPTION
# HID-2078

Our authentication/authorization policy to check if someone only had one possible rejection outcome: HTTP 403. We send 403 even if someone forgets credentials entirely.

[MDN says that 403 represents a rejection based on application logic](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403), and re-authenticating will have no effect. So we should not be sending 403s to people that forgot credentials. 401 is consistent with the rest of the app.

This PR adds a 401 response when credentials are missing, and continues returning 403 when the user authenticated properly, but does not have admin permissions.

One other thing: I wrapped the successful `return` statement in an explicit conditional because I feel like something as important as admin perms should not be implicitly allowed to return success. The previous code checked for one negative condition and returned true to everyone else. I've flipped it so that a positive detection of admin returns true, otherwise it returns the 403 error.

## Testing

This changes applies to v2/v3 so you can test the following route (since the v3 PR #109 is still open):

```
POST /api/v2/client

# send with no credentials => 401
# send with normal user => 403
# send with admin user => 400, unless you construct a valid payload
```

In this case seeing a 400 is as good as 200/204 because we only care about the authentication process, not the function of the endpoint itself.