### PR TITLE
HID-2081: DELETE /client/{id} should 404 when client doesn't exist

### DIFF
--- a/api/controllers/ClientController.js
+++ b/api/controllers/ClientController.js
@@ -210,10 +210,19 @@ module.exports = {
    *#     description: Requested client not found.
    */
   async destroy(request, reply) {
-    await Client.remove({ _id: request.params.id });
-    logger.info(
-      `[ClientController->destroy] Removed client ${request.params.id}`,
-    );
-    return reply.response().code(204);
+    const client = await Client.findOne({ _id: request.params.id });
+
+    // If a client was found, delete it and log the event.
+    if (client) {
+      await client.remove();
+
+      logger.info(
+        `[ClientController->destroy] Removed client ${request.params.id}`,
+      );
+      return reply.response().code(204);
+    }
+
+    // If no client was found, return 404.
+    return reply.response().code(404);
   },
 };

--- a/api/controllers/ClientController.js
+++ b/api/controllers/ClientController.js
@@ -223,6 +223,6 @@ module.exports = {
     }
 
     // If no client was found, return 404.
-    return reply.response().code(404);
+    throw Boom.notFound();
   },
 };

--- a/api/controllers/ClientController.js
+++ b/api/controllers/ClientController.js
@@ -206,8 +206,8 @@ module.exports = {
    *     description: Bad request. See response body for details.
    *   '403':
    *     description: Unauthorized. You are not an admin.
-   *#   '404':
-   *#     description: Requested client not found.
+   *   '404':
+   *     description: Requested client not found.
    */
   async destroy(request, reply) {
     const client = await Client.findOne({ _id: request.params.id });

--- a/docs/v3/hid.yml
+++ b/docs/v3/hid.yml
@@ -309,6 +309,8 @@ paths:
           description: Bad request. See response body for details.
         '403':
           description: Unauthorized. You are not an admin.
+        '404':
+          description: Requested client not found.
   /totp/qrcode:
     post:
       tags:
@@ -340,7 +342,7 @@ paths:
         - name: X-HID-TOTP
           in: header
           description: The TOTP token. Required.
-          required: false
+          required: true
           type: string
       requestBody:
         description: 'Must be an object specifying: `{"method": "app"}`'
@@ -373,7 +375,7 @@ paths:
         - name: X-HID-TOTP
           in: header
           description: The TOTP token. Required.
-          required: false
+          required: true
           type: string
       responses:
         '204':
@@ -388,7 +390,7 @@ paths:
         - name: X-HID-TOTP
           in: header
           description: The TOTP token. Required.
-          required: false
+          required: true
           type: string
       responses:
         '200':
@@ -429,7 +431,7 @@ paths:
         - name: X-HID-TOTP
           in: header
           description: The TOTP token. Required.
-          required: false
+          required: true
           type: string
       responses:
         '200':


### PR DESCRIPTION
# HID-2081

The operation to delete an OAuth client returned 204 no matter what happened inside the function. That meant successive calls to `DELETE /api/v3/client/{id}` would yield 204 every time. Now it does a lookup and 404s when nothing was found.

I updated the shared v2/v3 function but since this is an admin-only feature of HID, it's not bothering anyone to change behavior.