### PR TITLE
HID-2093: log payload during failed user creation

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -284,17 +284,32 @@ module.exports = {
    */
   async create(request) {
     if (!request.payload.app_verify_url) {
+      if (request.payload && request.payload.password) {
+        delete request.payload.password;
+      }
+      if (request.payload && request.payload.confirm_password) {
+        delete request.payload.confirm_password;
+      }
+
       logger.warn(
         '[UserController->create] Missing app_verify_url',
+        { request, security: true, fail: true }
       );
       throw Boom.badRequest('Missing app_verify_url');
     }
 
     const appVerifyUrl = request.payload.app_verify_url;
     if (!HelperService.isAuthorizedUrl(appVerifyUrl)) {
+      if (request.payload && request.payload.password) {
+        delete request.payload.password;
+      }
+      if (request.payload && request.payload.confirm_password) {
+        delete request.payload.confirm_password;
+      }
+
       logger.warn(
         `[UserController->create] app_verify_url ${appVerifyUrl} is not in authorizedDomains allowlist`,
-        { security: true, fail: true, request },
+        { request, security: true, fail: true },
       );
       throw Boom.badRequest('Invalid app_verify_url');
     }

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -258,6 +258,17 @@ module.exports = {
    *             required: true
    *             description: >-
    *               Should correspond to the endpoint you are interacting with.
+   *           password:
+   *             type: string
+   *             required: false
+   *             description: >-
+   *               See `/user/{id}/password` for password requirements.
+   *           confirm_password:
+   *             type: string
+   *             required: false
+   *             description: >-
+   *               See `/user/{id}/password` for password requirements. This
+   *               field is REQUIRED if `password` is sent in the payload.
    * responses:
    *   '200':
    *     description: User was successfully created

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -360,12 +360,15 @@ module.exports = {
         delete request.payload.tester;
       }
 
-      // Not showing request payload to avoid showing user passwords in logs.
       const user = await User.create(request.payload);
       if (!user) {
-        // Not showing request payload to avoid showing user passwords in logs.
+        // Delete sensitive fields before logging
+        delete request.payload.password;
+        delete request.payload.confirm_password;
+
         logger.warn(
           '[UserController->create] Create user failed',
+          { request: request.payload, fail: true },
         );
         throw Boom.badRequest();
       }

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -318,13 +318,23 @@ module.exports = {
       const requestIsV3 = request.path.indexOf('api/v3') !== -1;
       if (request.payload.password && request.payload.confirm_password) {
         if (requestIsV3 && !User.isStrongPasswordV3(request.payload.password)) {
+          // Remove sensitive fields before logging payload
+          delete request.payload.password;
+          delete request.payload.confirm_password;
+
           logger.warn(
             '[UserController->create] Provided password is not strong enough (v3)',
+            { request: request.payload, fail: true },
           );
           throw Boom.badRequest('The password is not strong enough');
         } else if (!User.isStrongPassword(request.payload.password)) {
+          // Remove sensitive fields before logging payload
+          delete request.payload.password;
+          delete request.payload.confirm_password;
+
           logger.warn(
             '[UserController->create] Provided password is not strong enough (v2)',
+            { request: request.payload, fail: true },
           );
           throw Boom.badRequest('The password is not strong enough');
         }

--- a/api/policies/UserPolicy.js
+++ b/api/policies/UserPolicy.js
@@ -45,13 +45,17 @@ module.exports = {
       if (!request.payload) {
         logger.warn(
           '[UserPolicy->canCreate] No request payload provided for user creation',
-          { fail: true, request: request.payload },
+          { request: request.payload, fail: true },
         );
         throw Boom.badRequest('Missing request payload');
       } else if (!request.payload.email) {
+        // Strip out sensitive fields before logging
+        delete request.payload.password;
+        delete request.payload.confirm_password;
+
         logger.warn(
           '[UserPolicy->canCreate] No email address provided for user creation',
-          { request: request.payload },
+          { request: request.payload, fail: true },
         );
         throw Boom.badRequest('You need to register with an email address');
       }

--- a/docs/v3/hid.yml
+++ b/docs/v3/hid.yml
@@ -486,6 +486,16 @@ paths:
                   type: string
                   required: true
                   description: Should correspond to the endpoint you are interacting with.
+                password:
+                  type: string
+                  required: false
+                  description: 'See `/user/{id}/password` for password requirements.'
+                confirm_password:
+                  type: string
+                  required: false
+                  description: >-
+                    See `/user/{id}/password` for password requirements. This
+                    field is REQUIRED if `password` is sent in the payload.
       responses:
         '200':
           description: User was successfully created

--- a/docs/v3/hid.yml
+++ b/docs/v3/hid.yml
@@ -10,6 +10,8 @@ servers:
     description: Dev server. For use by UNOCHA developers.
   - url: 'https://api.humanitarian.id/api/v3'
     description: Production server. For use by HID Integration Partners.
+  - url: 'http://api.hid.vm:3000/api/v3'
+    description: Localhost server. For your own debugging.
 tags:
   - name: auth
     description: Methods related to authentication

--- a/docs/v3/swaggerBase.yaml
+++ b/docs/v3/swaggerBase.yaml
@@ -11,6 +11,8 @@ servers:
     description: Dev server. For use by UNOCHA developers.
   - url: 'https://api.humanitarian.id/api/v3'
     description: Production server. For use by HID Integration Partners.
+  - url: 'http://api.hid.vm:3000/api/v3'
+    description: Localhost server. For your own debugging.
 
 tags:
   - name: 'auth'


### PR DESCRIPTION
# HID-2093

There was a comment in the API to not log an entire payload because the password was inside it. Far better to delete that property and send along any other info we have, since the event is logging a validation failure and people might want to debug or otherwise investigate.

While testing I found it in the security policy too.

I also found that I'd forgotten to document the `password` and `confirm_password` params in our new docs. Plus, I noticed that our v3 is also sending the wrong field (`password_confirm` instead of `confirm_password`) so that's a bug that might have otherwise sat for a while before being found.