### PR TITLE
HID-2092: log errors when querying DB for email confirmation

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1139,7 +1139,15 @@ module.exports = {
       throw Boom.badRequest();
     }
 
-    const record = await User.findOne({ _id: request.params.id });
+    const record = await User.findOne({ _id: request.params.id }).catch(err => {
+      logger.error(
+        err.message,
+        { request, fail: true, security: true },
+      );
+
+      throw Boom.internal('There is a problem querying to the database. Please try again.');
+    });
+
     if (!record) {
       logger.warn(
         `[UserController->setPrimaryEmail] Could not find user ${request.params.id}`,


### PR DESCRIPTION
# HID-2092

PR should help illuminate future problems with DB queries when testing on dev/stage. We sometimes have problems with `NOTABLESCAN` causing this query to fail sometimes, so it's helpful to log even if only for our non-prod environments.