### PR TITLE
HID-2077: prevent 500 during GET /user

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -490,17 +490,24 @@ module.exports = {
       }
       const user = await User.findOne(criteria);
 
-      if (!user) {
-        logger.warn(
-          `[UserController->find] Could not find user ${request.params.id}`,
-        );
-        throw Boom.notFound();
-      } else {
+      // If we found a user, return it
+      if (user) {
         user.sanitize(request.auth.credentials);
         user.translateListNames(reqLanguage);
         return user;
       }
+
+      // Finally: if we didn't find a user, send a 404.
+      logger.warn(
+        `[UserController->find] Could not find user ${request.params.id}`,
+      );
+      throw Boom.notFound();
     }
+
+    //
+    // No ID was sent so we are returning a list of users.
+    //
+
     const options = HelperService.getOptionsFromQuery(request.query);
     const criteria = HelperService.getCriteriaFromQuery(request.query);
     const childAttributes = User.listAttributes();

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -489,6 +489,7 @@ module.exports = {
         criteria.hidden = false;
       }
       const user = await User.findOne(criteria);
+
       if (!user) {
         logger.warn(
           `[UserController->find] Could not find user ${request.params.id}`,

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -912,7 +912,7 @@ UserSchema.methods = {
   sanitize(user) {
     this.sanitizeClients();
     this.sanitizeLists(user);
-    if (this._id.toString() !== user._id.toString() && !user.is_admin) {
+    if (this._id && user._id && this._id.toString() !== user._id.toString() && !user.is_admin) {
       if (this.emailsVisibility !== 'anyone') {
         if ((this.emailsVisibility === 'verified' && !user.verified)
         || (this.emailsVisibility === 'connections' && this.connectionsIndex(user._id) === -1)) {
@@ -960,7 +960,7 @@ UserSchema.methods = {
   },
 
   sanitizeLists(user) {
-    if (this._id.toString() !== user._id.toString() && !user.is_admin && !user.isManager) {
+    if (this._id && user._id && this._id.toString() !== user._id.toString() && !user.is_admin && !user.isManager) {
       const that = this;
       listTypes.forEach((attr) => {
         _.remove(that[`${attr}s`], (checkin) => {
@@ -1009,6 +1009,7 @@ UserSchema.methods = {
       });
     }
   },
+
   sanitizeClients() {
     if (this.authorizedClients && this.authorizedClients.length) {
       const sanitized = [];
@@ -1024,6 +1025,7 @@ UserSchema.methods = {
       }
     }
   },
+
   validPassword(password) {
     if (!this.password) {
       return false;

--- a/api/policies/UserPolicy.js
+++ b/api/policies/UserPolicy.js
@@ -88,4 +88,12 @@ module.exports = {
 
   canUpdate,
   canClaim: canUpdate,
+
+  async canFind(request) {
+    if (!!request.auth.credentials._id) {
+      return true;
+    }
+
+    throw Boom.unauthorized();
+  },
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -300,6 +300,9 @@ module.exports = [
     path: '/api/v2/user/{id?}',
     handler: UserController.find,
     options: {
+      pre: [
+        UserPolicy.canFind,
+      ],
       validate: {
         params: Joi.object({
           id: Joi.string().regex(objectIdRegex),
@@ -312,6 +315,9 @@ module.exports = [
     path: '/api/v3/user/{id}',
     handler: UserController.find,
     options: {
+      pre: [
+        UserPolicy.canFind,
+      ],
       validate: {
         params: Joi.object({
           id: Joi.string().regex(objectIdRegex),

--- a/templates/header.ejs
+++ b/templates/header.ejs
@@ -82,7 +82,7 @@
                 <h2 class="element-invisible" translate>User menu</h2>
 
                 <!-- anonymous user-login link -->
-                <div ng-if="!isAuthenticated" class="content">
+                <div class="content">
                   <ul class="menu cd-global-header__dropdown-btn cd-user-menu__item" role="menu">
                     <li class="cd-user-menu__icon-login">
                       <a href="/" class="login-link" translate>Login</a>


### PR DESCRIPTION
# HID-2077

We had a 500 when trying to GET `/user` on both v2 and v3. I have fixed the bug in case we somehow allow unauthenticated requests in the future, and also applied a new security policy called `canFind` which explicitly disallows unauthenticated requests.

The `canFind` can safely block unauthenticated GETs to both v2 and v3 because before this PR, they weren't returning data anyway. So instead of 500 this will 401 the request.