### PR TITLE
HID-2088: remove links from all email footers

### DIFF
--- a/emails/includes/footer_en.ejs
+++ b/emails/includes/footer_en.ejs
@@ -1,5 +1,4 @@
-<p>The Humanitarian ID team<br />
-Site: https://humanitarian.id<br />
-Twitter: https://twitter.com/humanitarianid<br />
-YouTube: https://www.youtube.com/c/humanitarianid<br />
-More information: https://about.humanitarian.id</p>
+<p>
+  The Humanitarian ID team<br>
+  More information: https://about.humanitarian.id
+</p>

--- a/emails/includes/footer_fr.ejs
+++ b/emails/includes/footer_fr.ejs
@@ -1,5 +1,4 @@
-<p>L’équipe Humanitarian ID<br />
-  Site: https://humanitarian.id<br />
-  Twitter: https://twitter.com/humanitarianid<br />
-  YouTube: https://www.youtube.com/c/humanitarianid<br />
-  Plus d'information: https://about.humanitarian.id</p>
+<p>
+  L’équipe Humanitarian ID<br>
+  Plus d'information: https://about.humanitarian.id
+</p>


### PR DESCRIPTION
# HID-2088

Small follow-up to remove social links from all email templates. They share common header/footer files so this will apply to any email we send.