### PR TITLE
Set stage as default origin for API docs

### DIFF
--- a/docs/v3/hid.yml
+++ b/docs/v3/hid.yml
@@ -6,12 +6,12 @@ info:
   license:
     name: Apache-2.0
 servers:
-  - url: 'https://dev.api-humanitarian-id.ahconu.org/api/v3'
-    description: Dev server. For use by UNOCHA developers.
+  - url: 'https://stage.api-humanitarian-id.ahconu.org/api/v3'
+    description: Staging server. For use by all UNOCHA developers.
   - url: 'https://api.humanitarian.id/api/v3'
-    description: Production server. For use by HID Integration Partners.
+    description: Production server. For use by HID Authentication Partners.
   - url: 'http://api.hid.vm:3000/api/v3'
-    description: Localhost server. For your own debugging.
+    description: Localhost server. For local dev/debugging.
 tags:
   - name: auth
     description: Methods related to authentication

--- a/docs/v3/swaggerBase.yaml
+++ b/docs/v3/swaggerBase.yaml
@@ -7,12 +7,12 @@ info:
     name: Apache-2.0
 
 servers:
-  - url: 'https://dev.api-humanitarian-id.ahconu.org/api/v3'
-    description: Dev server. For use by UNOCHA developers.
+  - url: 'https://stage.api-humanitarian-id.ahconu.org/api/v3'
+    description: Staging server. For use by all UNOCHA developers.
   - url: 'https://api.humanitarian.id/api/v3'
-    description: Production server. For use by HID Integration Partners.
+    description: Production server. For use by HID Authentication Partners.
   - url: 'http://api.hid.vm:3000/api/v3'
-    description: Localhost server. For your own debugging.
+    description: Localhost server. For local dev/debugging.
 
 tags:
   - name: 'auth'


### PR DESCRIPTION
We told all the teams to stop using dev and yet our API docs point to dev by default.