### PR TITLE
HID-2104: create separate admin-only JWT auth endpoint

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -248,6 +248,105 @@ module.exports = {
     );
     return { user: result, token };
   },
+  /*
+   * @api [post] /admintoken
+   * tags:
+   *   - auth
+   * summary: Admin-only route to generate a JSON web token (JWT)
+   * parameters:
+   *   - name: X-HID-TOTP
+   *     in: header
+   *     description: The TOTP token. Required if the user has 2FA enabled.
+   *     required: false
+   *     type: string
+   * requestBody:
+   *   description: 'User email and password'
+   *   required: true
+   *   content:
+   *     application/json:
+   *       schema:
+   *         $ref: '#/components/schemas/Auth'
+   * responses:
+   *   '200':
+   *     description: >-
+   *       The User object with the JWT contained in the `token` property.
+   *     content:
+   *       application/json:
+   *         schema:
+   *           $ref: '#/components/schemas/JWT'
+   *   '400':
+   *     description: 'Bad request. Missing email and/or password'
+   *   '401':
+   *     description: 'Wrong email and/or password'
+   *   '403':
+   *     description: 'Not an admin'
+   *   '429':
+   *     description: >-
+   *       The account was locked for 5 minutes because there were more than 5
+   *       unsuccessful login attempts within the last 5 minutes
+   * security: []
+   */
+  async authenticateAdmin(request) {
+    const result = await loginHelper(request);
+    if (result.totp === true) {
+      // Check to see if device is not a trusted device
+      const trusted = request.state['x-hid-totp-trust'];
+      if (!trusted || (trusted && !result.isTrustedDevice(request.headers['user-agent'], trusted))) {
+        const token = request.headers['x-hid-totp'];
+        await AuthPolicy.isTOTPValid(result, token);
+      }
+    }
+    const payload = { id: result._id };
+    if (request.payload && request.payload.exp) {
+      payload.exp = request.payload.exp;
+    }
+    const token = JwtService.issue(payload);
+    result.sanitize(result);
+
+    // Before proceeding, check if user has admin perms. This is the main
+    // difference between @authenticate and @authenticateAdmin
+    if (!result.is_admin) {
+      throw Boom.forbidden();
+    }
+
+    if (!payload.exp) {
+      // Creating an API key, store the token in the database
+      await JwtToken.create({
+        token,
+        user: result._id,
+        blacklist: false,
+        // TODO: add expires
+      });
+
+      logger.warn(
+        '[AuthController->authenticateAdmin] Created an API key',
+        {
+          request,
+          security: true,
+          user: {
+            email: result.email,
+          },
+        },
+      );
+      return {
+        user: result,
+        token,
+      };
+    }
+
+    logger.info(
+      '[AuthController->authenticateAdmin] Successful user authentication. Returning JWT.',
+      {
+        request,
+        security: true,
+        user: {
+          id: result.id,
+          email: result.email,
+        },
+      },
+    );
+    return { user: result, token };
+  },
 
   /**
    * Create a session and redirect to /oauth/authorize

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -288,6 +288,13 @@ module.exports = {
    */
   async authenticateAdmin(request) {
     const result = await loginHelper(request);
+
+    // Before proceeding, check if user has admin perms. This is the main
+    // difference between @authenticate and @authenticateAdmin
+    if (!result.is_admin) {
+      throw Boom.forbidden();
+    }
+
     if (result.totp === true) {
       // Check to see if device is not a trusted device
       const trusted = request.state['x-hid-totp-trust'];
@@ -302,12 +309,6 @@ module.exports = {
     }
     const token = JwtService.issue(payload);
     result.sanitize(result);
-
-    // Before proceeding, check if user has admin perms. This is the main
-    // difference between @authenticate and @authenticateAdmin
-    if (!result.is_admin) {
-      throw Boom.forbidden();
-    }
 
     if (!payload.exp) {
       // Creating an API key, store the token in the database

--- a/config/routes.js
+++ b/config/routes.js
@@ -259,6 +259,12 @@ module.exports = [
   },
 
   {
+    method: 'POST',
+    path: '/api/v3/admintoken',
+    handler: AuthController.authenticateAdmin,
+  },
+
+  {
     method: 'GET',
     path: '/api/v2/numbers',
     handler: NumbersController.numbers,

--- a/docs/v3/hid.yml
+++ b/docs/v3/hid.yml
@@ -177,6 +177,42 @@ paths:
           description: Missing token
         '403':
           description: Could not blacklist this token because you did not generate it
+  /admintoken:
+    post:
+      tags:
+        - auth
+      summary: Admin-only route to generate a JSON web token (JWT)
+      parameters:
+        - name: X-HID-TOTP
+          in: header
+          description: The TOTP token. Required if the user has 2FA enabled.
+          required: false
+          type: string
+      requestBody:
+        description: User email and password
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Auth'
+      responses:
+        '200':
+          description: The User object with the JWT contained in the `token` property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JWT'
+        '400':
+          description: Bad request. Missing email and/or password
+        '401':
+          description: Wrong email and/or password
+        '403':
+          description: Not an admin
+        '429':
+          description: >-
+            The account was locked for 5 minutes because there were more than 5
+            unsuccessful login attempts within the last 5 minutes
+      security: []
   /client:
     post:
       tags:

--- a/plugins/hapi-auth-hid/index.js
+++ b/plugins/hapi-auth-hid/index.js
@@ -110,6 +110,7 @@ internals.implementation = () => ({
       '/api/v2/jsonwebtoken',
       '/api/v3/user',
       '/api/v3/jsonwebtoken',
+      '/api/v3/admintoken',
     ];
 
     // Check for our special cases that are allowed to execute without an Auth


### PR DESCRIPTION
# HID-2104

We want a convenience method to authorize admins only. Since all endpoints are already covered by various security policies this is truly a convenience method to allow our HID Admin tool to block non-admin logins with a clear 403 response.