### PR TITLE
OPS-6862: ensure all error logs follow same conventions as info/warning

### DIFF
--- a/api/controllers/ServiceController.js
+++ b/api/controllers/ServiceController.js
@@ -275,7 +275,12 @@ module.exports = {
         } else {
           logger.error(
             '[ServiceController->subscribe] Error calling Mailchimp API',
-            { error: err },
+            {
+              fail: true,
+              error: err.message,
+              stack_trace: err.stack,
+              err_object: err,
+            },
           );
           throw err;
         }
@@ -346,7 +351,12 @@ module.exports = {
         } else {
           logger.error(
             '[ServiceController->unsubscribe] Error calling google groups API',
-            { error: err },
+            {
+              fail: true,
+              error: err.message,
+              err_object: err,
+              stack_trace: err.stack,
+            },
           );
           throw err;
         }

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -142,7 +142,17 @@ module.exports = {
         logger.warn(`Redirecting to ${request.query.redirect} is not allowed`, { security: true, fail: true, request });
         return reply.redirect('/');
       } catch (err) {
-        logger.error('Error logging user out', { request, error: err });
+        logger.error(
+          'Error logging user out',
+          {
+            request,
+            security: true,
+            fail: true,
+            error: err.message,
+            err_object: err,
+            stack_trace: err.stack,
+          },
+        );
         return reply.redirect('/');
       }
     } else {

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -1197,7 +1197,14 @@ UserSchema.methods = {
         }
       } catch (err) {
         // Invalid phone number
-        that.log.error('An invalid phone number was found', { error: err });
+        that.log.error(
+          'An invalid phone number was found',
+          {
+            error: err.message,
+            error_object: err,
+            stack_trace: err.stack,
+          },
+        );
       }
     });
     return found;

--- a/api/services/GSSSyncService.js
+++ b/api/services/GSSSyncService.js
@@ -88,7 +88,11 @@ async function writeUser(gsssync, authClient, user, index) {
   } catch (err) {
     logger.error(
       `[GSSSyncService->writeUser] Error writing user to spreadsheet ${gsssync.spreadsheet}`,
-      { error: err },
+      {
+        error: err.message,
+        err_object: err,
+        stack_trace: err.stack,
+      },
     );
     if (err.code === 404 || err.code === 403) {
       // Spreadsheet has been deleted, remove the synchronization
@@ -172,7 +176,12 @@ async function addUser(agsssync, user) {
   } catch (err) {
     logger.error(
       `[GSSSyncService->writeUser] Error adding user to spreadsheet ${gsssync.spreadsheet}`,
-      { error: err },
+      {
+        fail: true,
+        error: err.message,
+        err_object: err,
+        stack_trace: err.stack,
+      },
     );
     if (err.code === 404 || err.code === 403) {
       // Spreadsheet has been deleted, remove the synchronization
@@ -237,7 +246,11 @@ async function deleteUser(agsssync, hid) {
   } catch (err) {
     logger.error(
       `[GSSSyncService->deleteUser] Error removing user from spreadsheet ${gsssync.spreadsheet}`,
-      { error: err },
+      {
+        error: err.message,
+        err_object: err,
+        stack_trace: err.stack,
+      },
     );
     if (err.code === 404 || err.code === 403) {
       // Spreadsheet has been deleted, remove the synchronization
@@ -277,13 +290,27 @@ async function updateUser(agsssync, user) {
     } else {
       logger.warn(
         `[GSSSyncService->updateUser] Could not find user ${user._id} in spreadsheet ${gsssync.spreadsheet}`,
+        {
+          fail: true,
+          user: {
+            id: user._id,
+          },
+        },
       );
       throw new Error(`Could not find user ${user._id.toString()} for spreadsheet ${gsssync.spreadsheet}`);
     }
   } catch (err) {
     logger.error(
       `[GSSSyncService->updateUser] Error updating user in spreadsheet ${gsssync.spreadsheet}`,
-      { error: err },
+      {
+        fail: true,
+        error: err.message,
+        err_object: err,
+        stack_trace: err.stack,
+        user: {
+          id: user._id,
+        },
+      },
     );
     if (err.code === 404 || err.code === 403) {
       // Spreadsheet has been deleted, remove the synchronization


### PR DESCRIPTION
# OPS-6862

- Making sure that all instances of `hid.error` are one type of value (string in this case)
- Moved any error objects to a new `err_object` field.
- Added some `security`/`fail` flags when appropriate
