### PR TITLE
HID-2110: fix fatal errors during OAuth logins

### DIFF
--- a/config/logs.js
+++ b/config/logs.js
@@ -66,6 +66,8 @@ module.exports = {
       }
 
       // Sanitize OAuth client secrets
+      //
+      // This will display "00000...00000" in ELK.
       if (typeof metadata.request.query.client_secret === 'string') {
         // display first/last five characters but scrub the rest
         const sanitizedSecret = `${metadata.request.query.client_secret.slice(0, 5)}...${metadata.request.query.client_secret.slice(-5)}`;
@@ -95,6 +97,9 @@ module.exports = {
         let sanitizedJWT = metadata.request.headers.authorization.split('.');
         const buffer = Buffer.from(sanitizedJWT[1], 'base64');
         const asciiJWT = buffer.toString('ascii');
+
+        // Now pop the signature off to neuter the usefulness of the logged JWT
+        // and prevent ELK from storing actionable credentials.
         sanitizedJWT.pop();
         sanitizedJWT = sanitizedJWT.join('.');
         metadata.request.headers.authorization = sanitizedJWT;

--- a/config/logs.js
+++ b/config/logs.js
@@ -67,8 +67,8 @@ module.exports = {
 
       // Sanitize OAuth client secrets
       if (typeof metadata.request.query.client_secret === 'string') {
-        // display first/last three characters but scrub the rest
-        const sanitizedSecret = `${metadata.request.query.client_secret.slice(0, 3)}...${metadata.request.query.client_secret.slice(-3)}`;
+        // display first/last five characters but scrub the rest
+        const sanitizedSecret = `${metadata.request.query.client_secret.slice(0, 5)}...${metadata.request.query.client_secret.slice(-5)}`;
         metadata.request.query.client_secret = sanitizedSecret;
       }
 

--- a/config/logs.js
+++ b/config/logs.js
@@ -95,19 +95,23 @@ module.exports = {
         && metadata.request.headers.authorization.indexOf('Bearer') !== -1
       ) {
         let sanitizedJWT = metadata.request.headers.authorization.split('.');
-        const buffer = Buffer.from(sanitizedJWT[1], 'base64');
-        const asciiJWT = buffer.toString('ascii');
+        if (sanitizedJWT.length === 3) {
+          const buffer = Buffer.from(sanitizedJWT[1], 'base64');
+          const asciiJWT = buffer.toString('ascii');
 
-        // Now pop the signature off to neuter the usefulness of the logged JWT
-        // and prevent ELK from storing actionable credentials.
-        sanitizedJWT.pop();
-        sanitizedJWT = sanitizedJWT.join('.');
-        metadata.request.headers.authorization = sanitizedJWT;
+          // Now pop the signature off to neuter the usefulness of the logged JWT
+          // and prevent ELK from storing actionable credentials.
+          sanitizedJWT.pop();
+          sanitizedJWT = sanitizedJWT.join('.');
+          metadata.request.headers.authorization = sanitizedJWT;
 
-        // Auto-populate requesting user ID from JWT unless user.id was explicitly
-        // passed into the log.
-        if (typeof metadata.user.id === 'undefined') {
-          metadata.user.id = JSON.parse(asciiJWT).id;
+          // Auto-populate requesting user ID from JWT unless user.id was explicitly
+          // passed into the log.
+          if (typeof metadata.user.id === 'undefined') {
+            metadata.user.id = JSON.parse(asciiJWT).id;
+          }
+        } else {
+          // Skip JWT parsing
         }
       }
 


### PR DESCRIPTION
# HID-2110

The logging improvements from #128 were causing problems when sending requests with a Basic Auth header. Some cleanup and a few more filters to properly catch the Basic Auth header and also sanitize when found.

I am fairly certain the problem was introduced in 4ee6824 but since I ended up moving code between files I gave up when trying to bisect.

## Testing

Setup the [Extra-secure authorization process](https://github.com/UN-OCHA/hid_api/wiki/Integrating-with-HID-via-OAuth#extra-secure-authentication-process) to test locally. If the initial request does not 500, then the test is successful.

We are also working on patching some dev sites to have a permanent test mechanism on dev. See HID-2110 and OPS-6839 for details.