### PR TITLE
HID-2120: update URLs

### DIFF
--- a/emails/admin_delete/fr/html.ejs
+++ b/emails/admin_delete/fr/html.ejs
@@ -3,6 +3,6 @@
 <p><a href="<%= admin.getAppUrl() %>"><%= admin.name %></a> a supprimé votre compte.</p>
 
 <p>S’il s’agit d’une faute de notre part, nous vous prions de bien vouloir contacter <a href="<%= admin.getAppUrl() %>"><%= admin.name %></a> ou d’envoyer un courriel à info@humanitairan.id.
- Vous pouvez aussi recréer un nouveau compte à <a href="https://humanitarian.id/register">https://humanitarian.id/register</a>.</p>
+ Vous pouvez aussi recréer un nouveau compte à <a href="https://auth.humanitarian.id/register">https://auth.humanitarian.id/register</a>.</p>
 
 <% include ../../includes/footer_fr %>

--- a/emails/admin_delete/html.ejs
+++ b/emails/admin_delete/html.ejs
@@ -3,7 +3,7 @@
 <p><a href="<%= admin.getAppUrl() %>"><%= admin.name %></a> has deleted your account.</p>
 
 <p>If this action was taken in error, kindly contact <a href="<%= admin.getAppUrl() %>"><%= admin.name %></a> or email info@humanitairan.id.
- You can also create a new account at: <a href="https://humanitarian.id/register">https://humanitarian.id/register</a></p>
+ You can also create a new account at: <a href="https://auth.humanitarian.id/register">https://auth.humanitarian.id/register</a></p>
 
 <p>If you believe that this email was sent incorrectly or inappropriately, please let us know at info@humanitarian.id.</p>
 

--- a/emails/auth_to_profile/fr/html.ejs
+++ b/emails/auth_to_profile/fr/html.ejs
@@ -3,7 +3,7 @@
 <p>Nous voulions vous informer qu'un de nos managers, <a href="<%= createdBy.getAppUrl() %>"><%= createdBy.name %></a>, a créé
   un profil pour vous sur Humanitarian ID.</p>
 
-<p>Etant donné que vous avez déjà un compte sur Humanitarian ID, vous pouvez tout simplement vous connecter sur <a href="https://humanitarian.id">https://humanitarian.id</a>,
+<p>Etant donné que vous avez déjà un compte sur Humanitarian ID, vous pouvez tout simplement vous connecter sur <a href="https://auth.humanitarian.id">https://auth.humanitarian.id</a>,
   ajouter et gérer vos détails sur les listes de contacts humanitaaires et trouver facilement d'autres humanitaires.</p>
 
 <p>Si vous voulez en savoir plus à propos de Humanitarian ID et être le premier au courant des nouvelles fonctionnalités,

--- a/emails/auth_to_profile/html.ejs
+++ b/emails/auth_to_profile/html.ejs
@@ -3,7 +3,7 @@
 <p>We wanted to let you know that one of our managers, <a href="<%= createdBy.getAppUrl() %>"><%= createdBy.name %></a>, has created
   a profile for you on Humanitarian ID.</p>
 
-<p>As you already have a Humanitarian ID account, you can simply log in at <a href="https://humanitarian.id">https://humanitarian.id</a>,
+<p>As you already have a Humanitarian ID account, you can simply log in at <a href="https://auth.humanitarian.id">https://auth.humanitarian.id</a>,
   add and manage your details on humanitarian contact lists as well as easily find other responders.</p>
 
 <p>If you would like to learn more about Humanitarian ID and be the first to hear about new features,

--- a/emails/forced_password_reset/fr/html.ejs
+++ b/emails/forced_password_reset/fr/html.ejs
@@ -1,6 +1,6 @@
 <p>Bonjour <%= user.name %>,</p>
 
-<p>Conformément aux règlements de l'ONU, le mot de passe, comme mesure de sécurité, doit être changé tous les six mois. Nous souhaitons vous rappeler que votre mot de passe expirera aujourd'hui. Sachez qu'une fois que le mot de passe expiré, vous ne pourrez plus accéder au site Web <a href="https://humanitarian.id">Humanitarian ID</a> ni aux site webs <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partenaires</a>.</p>
+<p>Conformément aux règlements de l'ONU, le mot de passe, comme mesure de sécurité, doit être changé tous les six mois. Nous souhaitons vous rappeler que votre mot de passe expirera aujourd'hui. Sachez qu'une fois que le mot de passe expiré, vous ne pourrez plus accéder au site Web <a href="https://auth.humanitarian.id">Humanitarian ID</a> ni aux site webs <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partenaires</a>.</p>
 
 <p>Pour changer votre mot de passe, cliquez simplement sur le lien suivant : <a href="https://auth.humanitarian.id/password">https://auth.humanitarian.id/password</a></p>
 

--- a/emails/forced_password_reset/html.ejs
+++ b/emails/forced_password_reset/html.ejs
@@ -1,6 +1,6 @@
 <p>Dear <%= user.name %>,</p>
 
-<p>Following UN regulations, as a security measure passwords must be changed every six months. We would like to remind you that your Humanitarian ID password will expire today. Please be informed that once the password expires you will not be able to access the <a href="https://humanitarian.id">Humanitarian ID</a> website and any of the <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partner platforms</a>.</p>
+<p>Following UN regulations, as a security measure passwords must be changed every six months. We would like to remind you that your Humanitarian ID password will expire today. Please be informed that once the password expires you will not be able to access the <a href="https://auth.humanitarian.id">Humanitarian ID</a> website and any of the <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partner platforms</a>.</p>
 
 <p>To change your password, simply click on the following link: <a href="https://auth.humanitarian.id/password">https://auth.humanitarian.id/password</a></p>
 

--- a/emails/forced_password_reset_alert/fr/html.ejs
+++ b/emails/forced_password_reset_alert/fr/html.ejs
@@ -1,6 +1,6 @@
 <p>Bonjour <%= user.name %>,</p>
 
-<p>Conformément aux règlements de l'ONU, le mot de passe, comme mesure de sécurité, doit être changé tous les six mois. Nous souhaitons vous rappeler que votre mot de passe expirera dans 30 jours. Sachez qu'une fois que le mot de passe expiré, vous ne pourrez plus accéder au site Web <a href="https://humanitarian.id">Humanitarian ID</a> ni aux site webs <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partenaires</a>.</p>
+<p>Conformément aux règlements de l'ONU, le mot de passe, comme mesure de sécurité, doit être changé tous les six mois. Nous souhaitons vous rappeler que votre mot de passe expirera dans 30 jours. Sachez qu'une fois que le mot de passe expiré, vous ne pourrez plus accéder au site Web <a href="https://auth.humanitarian.id">Humanitarian ID</a> ni aux site webs <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partenaires</a>.</p>
 
 <p>Pour changer votre mot de passe, cliquez simplement sur le lien suivant : <a href="https://auth.humanitarian.id/password">https://auth.humanitarian.id/password</a></p>
 

--- a/emails/forced_password_reset_alert/html.ejs
+++ b/emails/forced_password_reset_alert/html.ejs
@@ -1,6 +1,6 @@
 <p>Dear <%= user.name %>,</p>
 
-<p>Following UN regulations, as a security measure passwords must be changed every six months. We would like to remind you that your Humanitarian ID password is about to expire in 30 days. Please be informed that once the password expires you will not be able to access the <a href="https://humanitarian.id">Humanitarian ID</a> website and any of the <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partner platforms</a>.</p>
+<p>Following UN regulations, as a security measure passwords must be changed every six months. We would like to remind you that your Humanitarian ID password is about to expire in 30 days. Please be informed that once the password expires you will not be able to access the <a href="https://auth.humanitarian.id">Humanitarian ID</a> website and any of the <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partner platforms</a>.</p>
 
 <p>To change your password, simply click on the following link: <a href="https://auth.humanitarian.id/password">https://auth.humanitarian.id/password</a></p>
 

--- a/emails/forced_password_reset_alert7/fr/html.ejs
+++ b/emails/forced_password_reset_alert7/fr/html.ejs
@@ -1,6 +1,6 @@
 <p>Bonjour <%= user.name %>,</p>
 
-<p>Conformément aux règlements de l'ONU, le mot de passe, comme mesure de sécurité, doit être changé tous les six mois. Nous souhaitons vous rappeler que votre mot de passe expirera dans sept jours. Sachez qu'une fois que le mot de passe expiré, vous ne pourrez plus accéder au site Web <a href="https://humanitarian.id">Humanitarian ID</a> ni aux site webs <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partenaires</a>.</p>
+<p>Conformément aux règlements de l'ONU, le mot de passe, comme mesure de sécurité, doit être changé tous les six mois. Nous souhaitons vous rappeler que votre mot de passe expirera dans sept jours. Sachez qu'une fois que le mot de passe expiré, vous ne pourrez plus accéder au site Web <a href="https://auth.humanitarian.id">Humanitarian ID</a> ni aux site webs <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partenaires</a>.</p>
 
 <p>Pour changer votre mot de passe, cliquez simplement sur le lien suivant : <a href="https://auth.humanitarian.id/password">https://auth.humanitarian.id/password</a></p>
 

--- a/emails/forced_password_reset_alert7/html.ejs
+++ b/emails/forced_password_reset_alert7/html.ejs
@@ -1,6 +1,6 @@
 <p>Dear <%= user.name %>,</p>
 
-<p>Following UN regulations, as a security measure passwords must be changed every six months. We would like to remind you that your Humanitarian ID password is about to expire in seven days. Please be informed that once the password expires you will not be able to access the <a href="https://humanitarian.id">Humanitarian ID</a> website and any of the <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partner platforms</a>.</p>
+<p>Following UN regulations, as a security measure passwords must be changed every six months. We would like to remind you that your Humanitarian ID password is about to expire in seven days. Please be informed that once the password expires you will not be able to access the <a href="https://auth.humanitarian.id">Humanitarian ID</a> website and any of the <a href="https://about.humanitarian.id/partners-using-our-authentication-service">partner platforms</a>.</p>
 
 <p>To change your password, simply click on the following link: <a href="https://auth.humanitarian.id/password">https://auth.humanitarian.id/password</a></p>
 

--- a/templates/message.html
+++ b/templates/message.html
@@ -13,7 +13,7 @@
         </div>
       <% } %>
       <% if (isSuccess) { %>
-        <p class="form-field">Now you can login on <a href="https://humanitarian.id" target="_blank">Humanitarian ID</a> or one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service" target="_blank">partner websites</a>.</p>
+        <p class="form-field">Now you can login on <a href="https://auth.humanitarian.id">Humanitarian ID</a> or one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service" target="_blank">partner websites</a>.</p>
       <% } %>
       </div>
     </div>


### PR DESCRIPTION
# HID-2120

Updating where we send people when we mention HID. We now point back at Auth instead of the soon-to-be decommissioned HID Contacts app.