### PR TITLE
HID-2125: point to HID Auth in OCHA Services

### DIFF
--- a/templates/header.ejs
+++ b/templates/header.ejs
@@ -53,7 +53,7 @@
                     <ul class="cd-ocha-dropdown__list">
                       <li class="cd-ocha-dropdown__link"><a href="https://fts.unocha.org/">Financial Tracking Service</a></li>
                       <li class="cd-ocha-dropdown__link"><a href="https://data.humdata.org/">Humanitarian Data Exchange</a></li>
-                      <li class="cd-ocha-dropdown__link"><a href="https://humanitarian.id/">Humanitarian ID</a></li>
+                      <li class="cd-ocha-dropdown__link"><a href="https://auth.humanitarian.id/">Humanitarian ID</a></li>
                       <li class="cd-ocha-dropdown__link"><a href="https://humanitarianresponse.info/">Humanitarian Response</a></li>
                     </ul>
                   </div>


### PR DESCRIPTION
# HID-2125

Update our CD Header to ensure that HID Auth points people back to itself if they somehow decide to click that link.