### PR TITLE
OPS-6803: fix inconsistent log conventions

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -88,7 +88,7 @@ async function loginHelper(request) {
         security: true,
         fail: true,
         user: {
-          id: user._id,
+          id: user.id,
           email,
         },
       },
@@ -103,7 +103,7 @@ async function loginHelper(request) {
         security: true,
         fail: true,
         user: {
-          id: user._id,
+          id: user.id,
           email,
         },
       },
@@ -119,6 +119,7 @@ async function loginHelper(request) {
         security: true,
         fail: true,
         user: {
+          id: user.id,
           email,
         },
       },
@@ -679,7 +680,7 @@ module.exports = {
             request,
             security: true,
             user: {
-              id: user._id,
+              id: user.id,
               email: user.email,
             },
             oauth: {

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -902,6 +902,7 @@ module.exports = {
                   request,
                   user: {
                     id: user._id.toString(),
+                    email: user.email,
                   },
                 },
               );
@@ -916,6 +917,7 @@ module.exports = {
                 request,
                 user: {
                   id: user._id.toString(),
+                  email: user.email,
                 },
               },
             );
@@ -929,6 +931,7 @@ module.exports = {
                 {
                   request,
                   user: {
+                    id: user.id,
                     email: user.email,
                   },
                 },
@@ -946,6 +949,7 @@ module.exports = {
                 request,
                 user: {
                   id: user.id,
+                  email: user.email,
                 },
               },
             );
@@ -962,6 +966,7 @@ module.exports = {
             request,
             user: {
               id: user.id,
+              email: user.email,
             },
           },
         );

--- a/api/services/GSSSyncService.js
+++ b/api/services/GSSSyncService.js
@@ -293,7 +293,7 @@ async function updateUser(agsssync, user) {
         {
           fail: true,
           user: {
-            id: user._id,
+            id: user.id,
           },
         },
       );
@@ -308,7 +308,7 @@ async function updateUser(agsssync, user) {
         err_object: err,
         stack_trace: err.stack,
         user: {
-          id: user._id,
+          id: user.id,
         },
       },
     );

--- a/plugins/hapi-auth-hid/index.js
+++ b/plugins/hapi-auth-hid/index.js
@@ -88,7 +88,12 @@ internals.tokenToUser = async (token) => {
       {
         security: true,
         user: {
-          id: tok.client.id,
+          admin: tok.user.is_admin,
+          id: tok.user.id,
+          email: tok.user.email,
+        },
+        oauth: {
+          client_id: tok.client.id,
         },
       },
     );


### PR DESCRIPTION
# OPS-6803

We had a couple issues reported in the ops ticket:

- `hid.user` had data of type `ObjectID` instead of strings sometimes
- `hid.error` had data of type `String` or sometimes `Error`  — but this seems to have been taken care of during 2020-09-30 deploy.

The PR has three fixes:
- attempts to get all the user ID stuff straightened out
- adds some additional attributes (email/ID) to a few logs
- fixes OAuth-authenticated requests to log the `client_id` inside `hid.oauth` instead of `hid.user`, and populated `hid.user` with correct data

## Testing

Can be complicated, but what I do is use GHO to log in on my local HID API:

- Add a GHO OAuth client to your local HID using the config from within GHO local drupal container.
- As drupal admin, go to https://gho.test/admin/config/social-api/social-auth/hid
- Under Advanced Settings, set the URL to be your local API: `http://api.hid.vm:3000`
- Open a shell to your GHO drupal container and run: `/sbin/ip route|awk '/default/ { print $3 }'` to get an IP to the host machine
- edit GHO drupal container's `/etc/hosts` to have `api.hid.vm` correspond to that IP
- tail logs in HID API container by running `docker-compose exec dev tail -f /var/log/local.log`
- in an incognito window, initiate an HID login from GHO website
- when prompted to enter a user/pass, choose something that exists, but has an expired password such as `verity@un.org`
- you should see the log entry contains a top-level property `user: { id: '[some string]' }` instead of the weird ObjectID which looks like this:

```json
"user":{"id":{"_bsontype":"ObjectID","id":{"0":91,"1":177,"2":216,"3":42,"4":43,"5":155,"6":251,"7":19,"8":17,"9":222,"10":191,"11":27}}}
```

- now login using a non-expired password account, and look for a log with the message `Successful authentication through OAuth token`
  - check that the `oauth: { client_id: 'something' }` exists
  - check that `user: { admin: boolean, id: 'string', email: 'address' }` exist