### PR TITLE
HID-2126 Password reset form and 2FA activation

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -56,8 +56,7 @@
               </section>
 
               <section id="section-delete">
-                <h2>Delete Account</h2>
-                <p>Button here</p>
+                <%- include('delete'); %>
               </section>
             </div>
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -12,26 +12,73 @@
             <div class="tabbed">
               <ul>
                 <li>
-                  <a href="#section-password">Password</a>
+                  <a href="#section-password" translate>Password</a>
                 </li>
                 <li>
-                  <a href="#section-apps">Authorized Apps</a>
+                  <a href="#section-apps" translate>Authorized Apps</a>
                 </li>
                 <li>
-                  <a href="#section-security">Security</a>
+                  <a href="#section-security" translate>Security</a>
                 </li>
                 <li>
-                  <a href="#section-delete">Delete Account</a>
+                  <a href="#section-delete" translate>Delete Account</a>
                 </li>
               </ul>
 
               <section id="section-password">
-                <h2>Change Password</h2>
-                <p>Form here</p>
+                <h2 translate>Change Password</h2>
+
+                <form onsubmit="changePassword()">
+
+                    <p translate>You must enter your current password to set a new password.</p>
+
+                    <input
+                      id="current-password"
+                      name="password"
+                      type="password"
+                      label="Password"
+                      autocomplete="current-password"
+                      placeholder=" "
+                      outlined
+                      required
+                    />
+
+                    <p translate>Passwords must be <strong>at least {{ $v.password.$params.minLength.min }} characters long</strong>, contain at least <strong>one number</strong>, <strong>one uppercase character</strong>, <strong>one lowercase character</strong>, and one <strong>special character: <code>!@#$%^&*()+=\`{}</code></strong>. Password has to be different than your previous one.</p>
+
+                    <input
+                      id="new-password"
+                      name="password"
+                      type="password"
+                      label="Password"
+                      autocomplete="new-password"
+                      placeholder=" "
+                      outlined
+                      required
+                    />
+
+                    <input
+                      id="new-password-confirm"
+                      name="passwordConfirm"
+                      type="password"
+                      label="Confirm Password"
+                      autocomplete="new-password"
+                      placeholder=" "
+                      outlined
+                      required
+                    />
+
+                    <button
+                      id="reset-password"
+                      class="cd-button cd-button--style"
+                      type="submit"
+                    >
+                      Reset Password
+                    </button>
+                </form>
               </section>
 
               <section id="section-apps">
-                <h2>Authorized Apps</h2>
+                <h2 translate>Authorized Apps</h2>
                 <ul>
                   <%
                     user.authorizedClients.forEach(function(client) {
@@ -51,12 +98,45 @@
               </section>
 
               <section id="section-security">
-                <h2>Two-factor authentication</h2>
-                <p>Status</p>
+                <h2 translate>Two-factor authentication</h2>
+
+                <% if (user.totp) { %>
+
+                <span class="status" style="color: #777;" translate>Status: <em>Enabled</em></span>
+                <p>&nbsp;</p>
+
+                <button class="cd-button cd-button--style cd-button--dectivate" onclick="goTo('deactivate');">
+                  Deactivate
+                </button>
+
+
+                <%} else { %>
+                  <span class="status" style="color: #777;" translate>Status: <em>Disabled</em></span>
+
+                  <p translate>Two-factor authentication is an effective way to protect your account from unauthorized access. What you need to do to enable this feature:</p>
+                  <ol>
+                    <li translate>If you don't have one yet, download an authenticator app (e.g. the Google Authenticator - <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en_GB" target="_blank" rel="noopener">Play Store</a>, <a href="https://itunes.apple.com/us/app/google-authenticator/id388497605?mt=8" target="_blank" rel="noopener">App Store</a>).</li>
+                    <li translate>Then click on the Activate button below</li>
+                    <li translate>After you have activated the Two-factor verification on this page you will see a QR-code that you need to scan with your authenticator app or you do the set-up manually.</li>
+                    <li translate>You'll then be sent a code to your mobile authenticator app.</li>
+                  </ol>
+                  <p translate>Two-factor authentication is an optional security feature. Once enabled, Humanitarian ID will require a six-digit security code or a security key in addition to your password if you wish to login or change your password. You can also set a device as trusted during login, you will then not be asked a seperate code on this device.</p>
+                  <p translate>After enabling two-factor authentication, you'll receive 16 backup codes. Copy these codes or download them and store them securely. Once a backup code is used, it can't be used again.</p>
+                  <p translate>You can remove the two-factor authentication at any point by clicking on ‘Deactivate’ button.</p>
+
+                  <button class="cd-button cd-button--style cd-button--activate" onclick="requestTotpConfig();">
+                    Activate
+                  </button>
+
+                <%# Steps to activate should go here #%>
+
+                <% } %>
+
               </section>
 
               <section id="section-delete">
-                <%- include('delete'); %>
+                <h2 translate>Delete Account</h2>
+                <p>Button here</p>
               </section>
             </div>
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -32,7 +32,22 @@
 
               <section id="section-apps">
                 <h2>Authorized Apps</h2>
-                <p>List here</p>
+                <ul>
+                  <%
+                    user.authorizedClients.forEach(function(client) {
+                  %>
+                  <li>
+                    <span><%= client.name %></span>
+                    <button type="button" class="cd-button cd-button--small cd-button--cancel" onclick="removeThisClient(client._id);">
+                      <svg class="cd-icon cd-icon--cancel">
+                        <use xlink:href="#cd-icon--cancel"></use>
+                      </svg>
+                    </button>
+                  </li>
+                  <%
+                  });
+                  %>
+                </ul>
               </section>
 
               <section id="section-security">
@@ -132,4 +147,44 @@
     tabs[0].setAttribute('aria-selected', 'true');
     panels[0].hidden = false;
   })();
+
+
+  function sortedClients() {
+    const sorted = this.profile.authorizedClients;
+    return sorted.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async function asyncData({ route, app: { $hid } }) {
+    // URL pattern: /settings/:slug
+    const currentTab = '/settings/clients';
+
+    // Get latest user account data.
+    const profile = await $hid.$get('/account.json');
+
+    return {
+      profile,
+      currentTab,
+    };
+  }
+
+  async function removeThisClient(idToBeRemoved) {
+    // Isolate client to be removed so we can prompt user for confirmation.
+    const clientToBeRemoved = this.profile.authorizedClients.filter(client => client._id === idToBeRemoved).pop();
+    const removalMessage = `Are you sure you want to remove ${clientToBeRemoved.name}? You will need to authorize the application again to access it through Humanitarian ID.`;
+
+    // Prompt user to confirm removal.
+    const userConfirmedRemoval = await this.$confirm(removalMessage);
+
+    // If they confirmed, then proceed with removal.
+    if (userConfirmedRemoval) {
+      // Remove client from the user's profile
+      const remainingClients = this.profile.authorizedClients.filter(client => client._id !== idToBeRemoved);
+      this.profile.authorizedClients = remainingClients;
+
+      // Update HID API
+      this.$hid.$put(`/api/v2/user/${this.me}`, this.profile);
+    }
+  }
+
+
 </script>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -11,71 +11,71 @@
 
             <div class="tabbed">
               <ul>
-                <li>
-                  <a href="#section-password" translate>Password</a>
-                </li>
+<!--                <li>-->
+<!--                  <a href="#section-password" translate>Password</a>-->
+<!--                </li>-->
                 <li>
                   <a href="#section-apps" translate>Authorized Apps</a>
                 </li>
-                <li>
-                  <a href="#section-security" translate>Security</a>
-                </li>
-                <li>
-                  <a href="#section-delete" translate>Delete Account</a>
-                </li>
+<!--                <li>-->
+<!--                  <a href="#section-security" translate>Security</a>-->
+<!--                </li>-->
+<!--                <li>-->
+<!--                  <a href="#section-delete" translate>Delete Account</a>-->
+<!--                </li>-->
               </ul>
 
-              <section id="section-password">
-                <h2 translate>Change Password</h2>
+<!--              <section id="section-password">-->
+<!--                <h2 translate>Change Password</h2>-->
 
-                <form onsubmit="changePassword()">
+<!--                <form onsubmit="changePassword()">-->
 
-                    <p translate>You must enter your current password to set a new password.</p>
+<!--                    <p translate>You must enter your current password to set a new password.</p>-->
 
-                    <input
-                      id="current-password"
-                      name="password"
-                      type="password"
-                      label="Password"
-                      autocomplete="current-password"
-                      placeholder=" "
-                      outlined
-                      required
-                    />
+<!--                    <input-->
+<!--                      id="current-password"-->
+<!--                      name="password"-->
+<!--                      type="password"-->
+<!--                      label="Password"-->
+<!--                      autocomplete="current-password"-->
+<!--                      placeholder=" "-->
+<!--                      outlined-->
+<!--                      required-->
+<!--                    />-->
 
-                    <p translate>Passwords must be <strong>at least {{ $v.password.$params.minLength.min }} characters long</strong>, contain at least <strong>one number</strong>, <strong>one uppercase character</strong>, <strong>one lowercase character</strong>, and one <strong>special character: <code>!@#$%^&*()+=\`{}</code></strong>. Password has to be different than your previous one.</p>
+<!--                    <p translate>Passwords must be <strong>at least {{ $v.password.$params.minLength.min }} characters long</strong>, contain at least <strong>one number</strong>, <strong>one uppercase character</strong>, <strong>one lowercase character</strong>, and one <strong>special character: <code>!@#$%^&*()+=\`{}</code></strong>. Password has to be different than your previous one.</p>-->
 
-                    <input
-                      id="new-password"
-                      name="password"
-                      type="password"
-                      label="Password"
-                      autocomplete="new-password"
-                      placeholder=" "
-                      outlined
-                      required
-                    />
+<!--                    <input-->
+<!--                      id="new-password"-->
+<!--                      name="password"-->
+<!--                      type="password"-->
+<!--                      label="Password"-->
+<!--                      autocomplete="new-password"-->
+<!--                      placeholder=" "-->
+<!--                      outlined-->
+<!--                      required-->
+<!--                    />-->
 
-                    <input
-                      id="new-password-confirm"
-                      name="passwordConfirm"
-                      type="password"
-                      label="Confirm Password"
-                      autocomplete="new-password"
-                      placeholder=" "
-                      outlined
-                      required
-                    />
+<!--                    <input-->
+<!--                      id="new-password-confirm"-->
+<!--                      name="passwordConfirm"-->
+<!--                      type="password"-->
+<!--                      label="Confirm Password"-->
+<!--                      autocomplete="new-password"-->
+<!--                      placeholder=" "-->
+<!--                      outlined-->
+<!--                      required-->
+<!--                    />-->
 
-                    <button
-                      id="reset-password"
-                      class="cd-button cd-button--style"
-                      type="submit"
-                    >
-                      Reset Password
-                    </button>
-                </form>
-              </section>
+<!--                    <button-->
+<!--                      id="reset-password"-->
+<!--                      class="cd-button cd-button&#45;&#45;style"-->
+<!--                      type="submit"-->
+<!--                    >-->
+<!--                      Reset Password-->
+<!--                    </button>-->
+<!--                </form>-->
+<!--              </section>-->
 
               <section id="section-apps">
                 <h2>Authorized Apps</h2>
@@ -104,47 +104,47 @@
                 </ul>
               </section>
 
-              <section id="section-security">
-                <h2 translate>Two-factor authentication</h2>
+<!--              <section id="section-security">-->
+<!--                <h2 translate>Two-factor authentication</h2>-->
 
-                <% if (user.totp) { %>
+<!--                <% if (user.totp) { %>-->
 
-                <span class="status" style="color: #777;" translate>Status: <em>Enabled</em></span>
-                <p>&nbsp;</p>
+<!--                <span class="status" style="color: #777;" translate>Status: <em>Enabled</em></span>-->
+<!--                <p>&nbsp;</p>-->
 
-                <button class="cd-button cd-button--style cd-button--dectivate" onclick="goTo('deactivate');">
-                  Deactivate
-                </button>
+<!--                <button class="cd-button cd-button&#45;&#45;style cd-button&#45;&#45;dectivate" onclick="goTo('deactivate');">-->
+<!--                  Deactivate-->
+<!--                </button>-->
 
 
-                <%} else { %>
-                  <span class="status" style="color: #777;" translate>Status: <em>Disabled</em></span>
+<!--                <%} else { %>-->
+<!--                  <span class="status" style="color: #777;" translate>Status: <em>Disabled</em></span>-->
 
-                  <p translate>Two-factor authentication is an effective way to protect your account from unauthorized access. What you need to do to enable this feature:</p>
-                  <ol>
-                    <li translate>If you don't have one yet, download an authenticator app (e.g. the Google Authenticator - <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en_GB" target="_blank" rel="noopener">Play Store</a>, <a href="https://itunes.apple.com/us/app/google-authenticator/id388497605?mt=8" target="_blank" rel="noopener">App Store</a>).</li>
-                    <li translate>Then click on the Activate button below</li>
-                    <li translate>After you have activated the Two-factor verification on this page you will see a QR-code that you need to scan with your authenticator app or you do the set-up manually.</li>
-                    <li translate>You'll then be sent a code to your mobile authenticator app.</li>
-                  </ol>
-                  <p translate>Two-factor authentication is an optional security feature. Once enabled, Humanitarian ID will require a six-digit security code or a security key in addition to your password if you wish to login or change your password. You can also set a device as trusted during login, you will then not be asked a seperate code on this device.</p>
-                  <p translate>After enabling two-factor authentication, you'll receive 16 backup codes. Copy these codes or download them and store them securely. Once a backup code is used, it can't be used again.</p>
-                  <p translate>You can remove the two-factor authentication at any point by clicking on ‘Deactivate’ button.</p>
+<!--                  <p translate>Two-factor authentication is an effective way to protect your account from unauthorized access. What you need to do to enable this feature:</p>-->
+<!--                  <ol>-->
+<!--                    <li translate>If you don't have one yet, download an authenticator app (e.g. the Google Authenticator - <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en_GB" target="_blank" rel="noopener">Play Store</a>, <a href="https://itunes.apple.com/us/app/google-authenticator/id388497605?mt=8" target="_blank" rel="noopener">App Store</a>).</li>-->
+<!--                    <li translate>Then click on the Activate button below</li>-->
+<!--                    <li translate>After you have activated the Two-factor verification on this page you will see a QR-code that you need to scan with your authenticator app or you do the set-up manually.</li>-->
+<!--                    <li translate>You'll then be sent a code to your mobile authenticator app.</li>-->
+<!--                  </ol>-->
+<!--                  <p translate>Two-factor authentication is an optional security feature. Once enabled, Humanitarian ID will require a six-digit security code or a security key in addition to your password if you wish to login or change your password. You can also set a device as trusted during login, you will then not be asked a seperate code on this device.</p>-->
+<!--                  <p translate>After enabling two-factor authentication, you'll receive 16 backup codes. Copy these codes or download them and store them securely. Once a backup code is used, it can't be used again.</p>-->
+<!--                  <p translate>You can remove the two-factor authentication at any point by clicking on ‘Deactivate’ button.</p>-->
 
-                  <button class="cd-button cd-button--style cd-button--activate" onclick="requestTotpConfig();">
-                    Activate
-                  </button>
+<!--                  <button class="cd-button cd-button&#45;&#45;style cd-button&#45;&#45;activate" onclick="requestTotpConfig();">-->
+<!--                    Activate-->
+<!--                  </button>-->
 
-                <%# Steps to activate should go here #%>
+<!--                <%# Steps to activate should go here #%>-->
 
-                <% } %>
+<!--                <% } %>-->
 
-              </section>
+<!--              </section>-->
 
-              <section id="section-delete">
-                <h2 translate>Delete Account</h2>
-                <p>Button here</p>
-              </section>
+<!--              <section id="section-delete">-->
+<!--                <h2 translate>Delete Account</h2>-->
+<!--                <p>Button here</p>-->
+<!--              </section>-->
             </div>
 
           </div>
@@ -234,41 +234,41 @@
   })();
 
 
-  function sortedClients() {
-    const sorted = this.profile.authorizedClients;
-    return sorted.sort((a, b) => a.name.localeCompare(b.name));
-  }
+  // function sortedClients() {
+  //   const sorted = this.profile.authorizedClients;
+  //   return sorted.sort((a, b) => a.name.localeCompare(b.name));
+  // }
 
-  async function asyncData({ route, app: { $hid } }) {
-    // URL pattern: /settings/:slug
-    const currentTab = '/settings/clients';
+  // function asyncData({ route, app: { $hid } }) {
+  //   // URL pattern: /settings/:slug
+  //   const currentTab = '/settings/clients';
+  //
+  //   // Get latest user account data.
+  //   const profile = await $hid.$get('/account.json');
+  //
+  //   return {
+  //     profile,
+  //     currentTab,
+  //   };
+  // }
 
-    // Get latest user account data.
-    const profile = await $hid.$get('/account.json');
-
-    return {
-      profile,
-      currentTab,
-    };
-  }
-
-  async function removeThisClient(idToBeRemoved) {
-    // Isolate client to be removed so we can prompt user for confirmation.
-    const clientToBeRemoved = this.profile.authorizedClients.filter(client => client._id === idToBeRemoved).pop();
-    const removalMessage = `Are you sure you want to remove ${clientToBeRemoved.name}? You will need to authorize the application again to access it through Humanitarian ID.`;
-
-    // Prompt user to confirm removal.
-    const userConfirmedRemoval = await this.$confirm(removalMessage);
-
-    // If they confirmed, then proceed with removal.
-    if (userConfirmedRemoval) {
-      // Remove client from the user's profile
-      const remainingClients = this.profile.authorizedClients.filter(client => client._id !== idToBeRemoved);
-      this.profile.authorizedClients = remainingClients;
-
-      // Update HID API
-      this.$hid.$put(`/api/v2/user/${this.me}`, this.profile);
-    }
-  }
+  // function removeThisClient(idToBeRemoved) {
+  //   // Isolate client to be removed so we can prompt user for confirmation.
+  //   const clientToBeRemoved = this.profile.authorizedClients.filter(client => client._id === idToBeRemoved).pop();
+  //   const removalMessage = `Are you sure you want to remove ${clientToBeRemoved.name}? You will need to authorize the application again to access it through Humanitarian ID.`;
+  //
+  //   // Prompt user to confirm removal.
+  //   const userConfirmedRemoval = await this.$confirm(removalMessage);
+  //
+  //   // If they confirmed, then proceed with removal.
+  //   if (userConfirmedRemoval) {
+  //     // Remove client from the user's profile
+  //     const remainingClients = this.profile.authorizedClients.filter(client => client._id !== idToBeRemoved);
+  //     this.profile.authorizedClients = remainingClients;
+  //
+  //     // Update HID API
+  //     this.$hid.$put(`/api/v2/user/${this.me}`, this.profile);
+  //   }
+  // }
 
 </script>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -272,7 +272,7 @@
   // }
 
 
-  async function deleteAccount(totpToken) {
+  function deleteAccount(totpToken) {
     // This value should only last as long as the function executes.
     let confirmed = false;
 
@@ -333,9 +333,9 @@
     // }
   }
 
-  function resetTotpPrompt() {
-    this.needsTotp = false;
-    this.alreadyConfirmed = false;
-  }
+  // function resetTotpPrompt() {
+  //   this.needsTotp = false;
+  //   this.alreadyConfirmed = false;
+  // }
 
 </script>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -143,7 +143,9 @@
 
 <!--              <section id="section-delete">-->
 <!--                <h2 translate>Delete Account</h2>-->
-<!--                <p>Button here</p>-->
+<!--                <button type="button" class="cd-button cd-button&#45;&#45;bold cd-button&#45;&#45;delete" onclick="deleteAccount();">-->
+<!--                  Delete-->
+<!--                </button>-->
 <!--              </section>-->
             </div>
 
@@ -283,7 +285,7 @@
     // // submitting, we'll wipe this value so that a second attempt to delete
     // // will require new confirmation.
     // if (!this.alreadyConfirmed) {
-    //   confirmed = await this.$confirm('Are you sure you want to do this? You will not be able to access Humanitarian ID anymore.');
+    //   confirmed = await this.$confirm('Are you sure you want to delete your Humanitarian ID account? You will no longer be able to access any of the HID-integrated platforms.');
     // }
     //
     // // If the user confirmed, or if TOTP is required (alreadyConfirmed)


### PR DESCRIPTION
Branched from https://github.com/UN-OCHA/hid_api/pull/159

1. Currently placeholder markup only for both Password reset form, and 2FA tab
2. TOTP conditional based on vue app, but missing the "Activation Steps. TBD

![Screenshot from 2020-11-03 16-46-03](https://user-images.githubusercontent.com/1835923/98009018-685c3b00-1df5-11eb-8c72-4225488f20fb.png)

![Screenshot from 2020-11-03 16-46-11](https://user-images.githubusercontent.com/1835923/98009027-6b572b80-1df5-11eb-8588-2c2889604cf7.png)

![Screenshot from 2020-11-03 16-49-00](https://user-images.githubusercontent.com/1835923/98009041-6e521c00-1df5-11eb-84e0-83933ae50768.png)
