### PR TITLE
HID-2131: auth password v3

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -2198,6 +2198,9 @@ module.exports = {
             request,
             security: true,
             fail: true,
+            user: {
+              id: request.payload.id,
+            },
           },
         );
         throw Boom.badRequest('Could not reset password');

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -331,25 +331,12 @@ module.exports = {
         request.payload.emails.push({ type: 'Work', email: request.payload.email, validated: false });
       }
 
-      // Business logic: is the new password strong enough?
-      //
-      // v2 and v3 have different requirements so we check the request path before
-      // checking the password strength.
-      const requestIsV3 = request.path.indexOf('api/v3') !== -1;
       if (request.payload.password && request.payload.confirm_password) {
-        if (requestIsV3 && !User.isStrongPasswordV3(request.payload.password)) {
+        if (User.isStrongPassword(request.payload.password)) {
+          request.payload.password = User.hashPassword(request.payload.password);
+        } else {
           logger.warn(
-            '[UserController->create] Provided password is not strong enough (v3)',
-            {
-              request,
-              security: true,
-              fail: true,
-            },
-          );
-          throw Boom.badRequest('The password is not strong enough');
-        } else if (!User.isStrongPassword(request.payload.password)) {
-          logger.warn(
-            '[UserController->create] Provided password is not strong enough (v2)',
+            '[UserController->create] Provided password is not strong enough.',
             {
               request,
               security: true,
@@ -358,11 +345,11 @@ module.exports = {
           );
           throw Boom.badRequest('The password is not strong enough');
         }
-        request.payload.password = User.hashPassword(request.payload.password);
       } else {
         // Set a random password
         request.payload.password = User.hashPassword(User.generateRandomPassword());
       }
+
       delete request.payload.app_verify_url;
 
       let notify = true;
@@ -1101,11 +1088,7 @@ module.exports = {
     }
 
     // Business logic: is the new password strong enough?
-    //
-    // v2 and v3 have different requirements so we check the request path before
-    // checking the password strength.
-    const requestIsV3 = request.path.indexOf('api/v3') !== -1;
-    if (requestIsV3 && !User.isStrongPasswordV3(request.payload.new_password)) {
+    if (!User.isStrongPassword(request.payload.new_password)) {
       logger.warn(
         `[UserController->updatePassword] Could not update user password for user ${user.id}. New password is not strong enough (v3)`,
         {
@@ -1115,16 +1098,6 @@ module.exports = {
         },
       );
       throw Boom.badRequest('New password does not meet requirements');
-    } else if (!User.isStrongPassword(request.payload.new_password)) {
-      logger.warn(
-        `[UserController->updatePassword] Could not update user password for user ${user.id}. New password is not strong enough (v2)`,
-        {
-          request,
-          security: true,
-          fail: true,
-        },
-      );
-      throw Boom.badRequest('New password is not strong enough');
     }
 
     // Was the current password entered correctly?
@@ -2183,24 +2156,9 @@ module.exports = {
       throw Boom.badRequest('Wrong arguments');
     }
 
-    // Business logic: is the new password strong enough?
-    //
-    // v2 and v3 have different requirements so we check the request path before
-    // checking the password strength.
-    const requestIsV3 = request.path.indexOf('api/v3') !== -1;
-    if (requestIsV3 && !User.isStrongPasswordV3(request.payload.password)) {
+    if (!User.isStrongPassword(request.payload.password)) {
       logger.warn(
-        '[UserController->resetPasswordEndpoint] Could not reset password. New password is not strong enough (v3)',
-        {
-          request,
-          security: true,
-          fail: true,
-        },
-      );
-      throw Boom.badRequest('New password is not strong enough');
-    } else if (!User.isStrongPassword(request.payload.password)) {
-      logger.warn(
-        '[UserController->resetPasswordEndpoint] Could not reset password. New password is not strong enough (v2)',
+        '[UserController->resetPasswordEndpoint] Could not reset password. New password is not strong enough',
         {
           request,
           security: true,
@@ -2227,7 +2185,10 @@ module.exports = {
       const token = request.headers['x-hid-totp'];
       record = await AuthPolicy.isTOTPValid(record, token);
     }
+
     let domain = null;
+
+    // Check that the reset hash was correct when the user landed on the page.
     if (record.validHash(request.payload.hash, 'reset_password', request.payload.time) === true) {
       // Check the new password against the old one.
       if (record.validPassword(request.payload.password)) {

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -332,6 +332,18 @@ module.exports = {
       }
 
       if (request.payload.password && request.payload.confirm_password) {
+        if (request.payload.password !== request.payload.confirm_password) {
+          logger.warn(
+            '[UserController->create] Passwords did not match during registration.',
+            {
+              request,
+              security: true,
+              fail: true,
+            },
+          );
+          throw Boom.badRequest('The passwords do not match');
+        }
+
         if (User.isStrongPassword(request.payload.password)) {
           request.payload.password = User.hashPassword(request.payload.password);
         } else {

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -180,8 +180,17 @@ module.exports = {
     try {
       await recaptcha.validate(request.payload['g-recaptcha-response']);
     } catch (err) {
+      logger.warn(
+        '[ViewController->registerPost] Failure during reCAPTCHA validation.',
+        {
+          request,
+          security: true,
+          fail: true,
+        },
+      );
+
       return reply.view('login', {
-        alert: { type: 'danger', message: recaptcha.translateErrors(err) },
+        alert: { type: 'danger', message: 'There was a problem validating your registration. Please try again.' },
         query: request.query,
         registerLink,
         passwordLink,

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -339,14 +339,20 @@ module.exports = {
         await UserController.resetPasswordEndpoint(request);
         if (params) {
           return reply.view('login', {
-            alert: { type: 'success', message: 'Your password was successfully reset. You can now login.' },
+            alert: {
+              type: 'success',
+              message: 'Your password was successfully reset. You can now login.',
+            },
             query: request.payload,
             registerLink,
             passwordLink,
           });
         }
         return reply.view('message', {
-          alert: { type: 'success', message: 'Thank you for updating your password.' },
+          alert: {
+            type: 'success',
+            message: 'Thank you for updating your password.',
+          },
           query: request.payload,
           isSuccess: true,
           title: 'Password update',
@@ -354,7 +360,10 @@ module.exports = {
       } catch (err) {
         if (params) {
           return reply.view('login', {
-            alert: { type: 'danger', message: 'There was an error resetting your password.' },
+            alert: {
+              type: 'danger',
+              message: 'There was an error resetting your password. Please try again.',
+            },
             query: request.payload,
             registerLink,
             passwordLink,

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -203,7 +203,10 @@ module.exports = {
       });
     }
     try {
+      // Attempt to create a new HID account.
       await UserController.create(request);
+
+      // Render login form with success message.
       return reply.view('login', {
         alert: {
           type: 'success',
@@ -214,11 +217,22 @@ module.exports = {
         passwordLink,
       });
     } catch (err) {
-      let userMessage = err.output && err.output.payload && err.output.payload.message.indexOf('password is not strong') !== -1
-        ? 'Your password was not strong enough. Please check the requirements and try again.'
-        : 'There is an error in your registration. You may have already registered. If so, simply reset your password at https://auth.humanitarian.id/password.';
+      // Check if we have an error worth telling the user about.
+      const errorMessage = err.output && err.output.payload && err.output.payload.message;
+      let userMessage = 'There is an error in your registration. You may have already registered. If so, simply reset your password at https://auth.humanitarian.id/password.';
+
+      // Check the error for a few special cases to provide better user feedback.
+      if (errorMessage && errorMessage.indexOf('password is not strong') !== -1) {
+        userMessage = 'Your password was not strong enough. Please check the requirements and try again.';
+      }
+      if (errorMessage && errorMessage.indexOf('passwords do not match') !== -1) {
+        userMessage = 'Your password fields did not match. Please try again and carefully confirm the password.';
+      }
+
+      // Add a domain from the allow-list.
       const requestUrl = _buildRequestUrl(request, 'register');
 
+      // Render registration form.
       return reply.view('register', {
         alert: {
           type: 'danger',

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -221,7 +221,23 @@ module.exports = {
       const errorMessage = err.output && err.output.payload && err.output.payload.message;
       let userMessage = 'There is an error in your registration. You may have already registered. If so, simply reset your password at https://auth.humanitarian.id/password.';
 
+      // If the error says the email already exists, we'll redirect to login.
+      if (errorMessage && errorMessage.indexOf('is already registered') !== -1) {
+        userMessage = 'That email address is already registered. Please login, or if you\'ve forgotten your password, reset using the link below.';
+
+        return reply.view('login', {
+          alert: {
+            type: 'danger',
+            message: userMessage,
+          },
+          query: request.query,
+          registerLink,
+          passwordLink,
+        });
+      }
+
       // Check the error for a few special cases to provide better user feedback.
+      // All of these will render the registration form.
       if (errorMessage && errorMessage.indexOf('password is not strong') !== -1) {
         userMessage = 'Your password was not strong enough. Please check the requirements and try again.';
       }

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -369,11 +369,15 @@ module.exports = {
             passwordLink,
           });
         }
-        return reply.view('message', {
-          alert: { type: 'danger', message: 'There was an error resetting your password.' },
+
+        const requestUrl = _buildRequestUrl(request, 'new_password');
+        return reply.view('password', {
+          alert: {
+            type: 'danger',
+            message: 'There was an error resetting your password. Please try again.',
+          },
           query: request.payload,
-          isSuccess: false,
-          title: 'Password update',
+          requestUrl,
         });
       }
     }

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -164,6 +164,9 @@ module.exports = {
     const requestUrl = _buildRequestUrl(request, 'verify2');
     return reply.view('register', {
       title: 'Register a Humanitarian ID account',
+      formEmail: '',
+      formGivenName: '',
+      formFamilyName: '',
       requestUrl,
       recaptcha_site_key: process.env.RECAPTCHA_PUBLIC_KEY,
     });
@@ -208,12 +211,19 @@ module.exports = {
       let userMessage = err.output && err.output.payload && err.output.payload.message.indexOf('password is not strong') !== -1
         ? 'Your password was not strong enough. Please check the requirements and try again.'
         : 'There is an error in your registration. You may have already registered. If so, simply reset your password at https://auth.humanitarian.id/password.';
+      const requestUrl = _buildRequestUrl(request, 'register');
 
-      return reply.view('login', {
-        alert: { type: 'danger', message: userMessage },
+      return reply.view('register', {
+        alert: {
+          type: 'danger',
+          message: userMessage,
+        },
         query: request.query,
-        registerLink,
-        passwordLink,
+        formEmail: request.payload.email,
+        formGivenName: request.payload.given_name,
+        formFamilyName: request.payload.family_name,
+        requestUrl,
+        recaptcha_site_key: process.env.RECAPTCHA_PUBLIC_KEY,
       });
     }
   },

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -193,7 +193,10 @@ module.exports = {
       );
 
       return reply.view('login', {
-        alert: { type: 'danger', message: 'There was a problem validating your registration. Please try again.' },
+        alert: {
+          type: 'danger',
+          message: 'There was a problem validating your registration. Please try again.',
+        },
         query: request.query,
         registerLink,
         passwordLink,
@@ -202,7 +205,10 @@ module.exports = {
     try {
       await UserController.create(request);
       return reply.view('login', {
-        alert: { type: 'success', message: 'Thank you for creating an account. You will soon receive a confirmation email to confirm your account.' },
+        alert: {
+          type: 'success',
+          message: 'Thank you for creating an account. You will soon receive a confirmation email to confirm your account.',
+        },
         query: request.query,
         registerLink,
         passwordLink,

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -205,8 +205,12 @@ module.exports = {
         passwordLink,
       });
     } catch (err) {
+      let userMessage = err.output && err.output.payload && err.output.payload.message.indexOf('password is not strong') !== -1
+        ? 'Your password was not strong enough. Please check the requirements and try again.'
+        : 'There is an error in your registration. You may have already registered. If so, simply reset your password at https://auth.humanitarian.id/password.';
+
       return reply.view('login', {
-        alert: { type: 'danger', message: 'There is an error in your registration. You may have already registered. If so, simply reset your password at https://auth.humanitarian.id/password.' },
+        alert: { type: 'danger', message: userMessage },
         query: request.query,
         registerLink,
         passwordLink,

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -839,18 +839,7 @@ UserSchema.statics = {
     return index;
   },
 
-  // v2 — Password Requirements
-  //
-  // - At least 8 characters total
-  // - At least one number
-  // - At least one lowercase letter
-  // - At least one uppercase letter
-  isStrongPassword(password) {
-    const regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/;
-    return password.length > 7 && regex.test(password);
-  },
-
-  // v3 — Password Requirements
+  // Password Requirements
   //
   // As of 2020 we follow the most strict guidelines in order to avoid the OICT
   // requirement that we expire weak passwords after 6 months.
@@ -860,7 +849,7 @@ UserSchema.statics = {
   // - At least one lowercase letter
   // - At least one uppercase letter
   // - At least one special character: !@#$%^&*()+=\`{}
-  isStrongPasswordV3(password) {
+  isStrongPassword(password) {
     const regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$/;
     return password.length >= 12 && regex.test(password);
   },

--- a/templates/formassets.ejs
+++ b/templates/formassets.ejs
@@ -1,0 +1,58 @@
+<style>
+  input:focus:invalid {
+    color: red;
+    border-bottom-color: currentColor;
+    box-shadow: inset 0px -1px 0px 0px currentColor;
+  }
+  .form-field code {
+    display: inline-block;
+    background: #eee;
+    border-radius: 3px;
+    padding-left: .25em;
+    padding-right: .25em;
+  }
+</style>
+
+<script type="text/javascript">
+  //
+  // Password strength
+  //
+  // The password strength is ultimately enforced in the HID API, but we can
+  // double check here and prompt the user to submit a strong password beforehand.
+  //
+  function checkPassword(password) {
+    var passwordStrength = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$/;
+    return password.length >= 12 && passwordStrength.test(password);
+  }
+
+  //
+  // Form validation
+  //
+  function checkForm(form) {
+    // Do the passwords match?
+    if (form.password.value === form.confirm_password.value) {
+      // Is the password strong enough?
+      if (checkPassword(form.password.value)) {
+        // Submit form.
+        return true;
+      } else {
+        // Password needs to be stronger.
+        alert("The password you have entered is not strong enough! Make sure it has at least 12 characters with one number, one lowercase, one uppercase, and one special character.");
+        form.password.focus();
+
+        return false;
+      }
+    } else {
+      // Passwords didn't match.
+      alert("The passwords do not match. Please confirm your password by entering it again.");
+      form.confirm_password.value = '';
+      form.confirm_password.focus();
+
+      return false;
+    }
+
+    // If we fall through all conditions, return false and allow the HTML5 form
+    // validation to kick in.
+    return false;
+  }
+</script>

--- a/templates/login.html
+++ b/templates/login.html
@@ -4,7 +4,7 @@
   <main role="main" id="main-content" class="cd-container">
     <div class="cd-layout-content">
       <div class="row">
-        <div class="col-sm-6 offset-sm-3 col-lg-4 offset-lg-4">
+        <div class="col-sm-10 offset-sm-1 col-md-8 offset-md-2">
           <div class="page-header">
             <h1 class="page-header__heading">Log in</h1>
           </div>

--- a/templates/message.html
+++ b/templates/message.html
@@ -15,7 +15,6 @@
       <% if (isSuccess) { %>
         <p class="form-field">Now you can login on <a href="https://auth.humanitarian.id">Humanitarian ID</a> or one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service" target="_blank">partner websites</a>.</p>
       <% } %>
-      </div>
     </div>
   </div>
 </div>

--- a/templates/new_password.html
+++ b/templates/new_password.html
@@ -1,48 +1,44 @@
 <% include header %>
 
-<script type="text/javascript">
-  function checkPassword(str)
-  {
-    var re = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}$/;
-    return re.test(str);
-  }
-
-  function checkForm(form)
-  {
-    if(form.password.value != "" && form.password.value == form.confirmPassword.value) {
-      if(!checkPassword(form.password.value)) {
-        alert("The password you have entered is not valid ! Make sure it has at least 8 characters with one number, one lowercase and one uppercase character.");
-        form.password.focus();
-        return false;
-      }
-    } else {
-      alert("Please check that you've entered and confirmed your password !");
-      form.password.focus();
-      return false;
-    }
-    return true;
-  }
-</script>
-
 <div class="container api-page">
   <div class="row">
-    <div class="col-sm-6 offset-sm-3 col-lg-4 offset-lg-4">
+    <div class="col-sm-10 offset-sm-1 col-md-8 offset-md-2">
       <div class="page-header">
         <h1 class="page-header__heading">Enter your new password</h1>
       </div>
 
-      <p>Passwords must be at least <strong>8 characters</strong> long, contain at least
-      <strong>one number</strong>, one <strong>uppercase character</strong> and one
-      <strong>lowercase character</strong>. Password has to be different than your previous one.</p>
-
       <form name="resetPassword" action="/new_password" method="POST" onsubmit="return checkForm(this)">
       <div class="form-field">
           <label for="password">New password</label>
-          <input type="password" name="password" id="password" required>
+          <input
+            type="password"
+            name="password"
+            id="password"
+            required
+            minlength="12"
+            pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
+            title="See password requirements below.">
         </div>
         <div class="form-field">
           <label for="confirm_password">Confirm new password</label>
-          <input type="password" name="confirmPassword" id="confirm_password" required>
+          <input
+            type="password"
+            name="confirm_password"
+            id="confirm_password"
+            required
+            minlength="12"
+            pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
+            title="See password requirements below.">
+        </div>
+        <div class="form-field">
+          <p>Passwords must be at least 12 characters long and:</p>
+          <ul>
+            <li>Contain <strong>one number</strong></li>
+            <li>Contain <strong>one uppercase character</strong></li>
+            <li>Contain <strong>one lowercase character</strong></li>
+            <li>Contain <strong>one special character</strong> <code>!@#$%^&*()+=\`{}</code></li>
+            <li>Be different than your previous password</li>
+          </ul>
         </div>
         <input type="hidden" name="redirect" value="<%= query.redirect %>" />
         <input type="hidden" name="client_id" value="<%= query.client_id %>" />
@@ -58,4 +54,6 @@
     </div>
   </div>
 </div>
+
+<% include formassets %>
 <% include footer %>

--- a/templates/password.html
+++ b/templates/password.html
@@ -2,18 +2,20 @@
 
 <div class="container api-page">
   <div class="row">
-    <div class="global-header__back">
-      <button type="button" class="btn-transparent" onclick="window.history.back()">
-        < Back
-      </button>
-    </div>
-    <div class="col-sm-6 offset-sm-3 col-lg-4 offset-lg-4">
-
+    <div class="col-sm-10 offset-sm-1 col-md-8 offset-md-2">
       <div class="page-header">
         <h1 class="page-header__heading">Reset Password</h1>
+
+        <% if (typeof alert !== 'undefined') { %>
+          <div class="alert alert--inline alert--<%= alert.type %>" role="alert">
+            <div class="alert__inner">
+              <%= alert.message %>
+            </div>
+          </div>
+        <% } %>
+
         <p class="form-field">If you forgot the password to your Humanitarian ID account, or your password has expired, you can request a new password by entering your email address here and clicking "Reset Password". You will receive an email with a temporary link.</p>
         <p class="form-field">Note: Allow some time for the email to get to your inbox (especially if using @un.org domain). If you do not receive it, get in touch with us at <a href="mailto:info@humanitarian.id">info@humanitarian.id</a></p>
-
       </div>
 
 			<form name="reset" action="/password" method="POST">

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,29 +1,6 @@
 <% include header %>
 
-<script src='https://www.google.com/recaptcha/api.js'></script>
-<script type="text/javascript">
-  function checkPassword(str)
-  {
-    var re = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}$/;
-    return re.test(str);
-  }
-
-  function checkForm(form)
-  {
-    if(form.password.value != "" && form.password.value == form.confirm_password.value) {
-      if(!checkPassword(form.password.value)) {
-        alert("The password you have entered is not valid ! Make sure it has at least 8 characters with one number, one lowercase and one uppercase character.");
-        form.password.focus();
-        return false;
-      }
-    } else {
-      alert("Please check that you've entered and confirmed your password !");
-      form.password.focus();
-      return false;
-    }
-    return true;
-  }
-</script>
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>
 
 <div class="container api-page">
   <div class="row">
@@ -34,7 +11,7 @@
       <form name="register" action="/register" method="POST" onsubmit="return checkForm(this)">
         <div class="form-field">
           <label for="email" translate>Email</label>
-          <input type="email" name="email" id="email" placeholder="Your email address" required>
+          <input type="email" name="email" id="email" placeholder="you@example.com" required>
         </div>
         <div class="form-field">
           <label for="given_name">First Name</label>
@@ -45,17 +22,36 @@
           <input type="text" name="family_name" id="family_name" placeholder="Your last name" required>
         </div>
         <div class="form-field">
-          <p class="help-block">
-            Passwords must be at least <strong>8 characters</strong> long, contain at least
-            <strong>one number</strong>, one <strong>uppercase character</strong> and one
-            <strong>lowercase character</strong>.
-          </p>
           <label for="password">Password</label>
-          <input type="password" name="password" id="password" placeholder="" required>
+          <input
+            type="password"
+            name="password"
+            id="password"
+            required
+            minlength="12"
+            pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
+            title="See password requirements below.">
         </div>
         <div class="form-field">
-          <label for="confirm_password">Password (confirm)</label>
-          <input type="password" name="confirm_password" id="confirm_password" placeholder="" required>
+          <label for="confirm_password">Confirm password</label>
+          <input
+            type="password"
+            name="confirm_password"
+            id="confirm_password"
+            required
+            minlength="12"
+            pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
+            title="See password requirements below.">
+        </div>
+        <div class="form-field">
+          <p>Passwords must be at least 12 characters long and:</p>
+          <ul>
+            <li>Contain <strong>one number</strong></li>
+            <li>Contain <strong>one uppercase character</strong></li>
+            <li>Contain <strong>one lowercase character</strong></li>
+            <li>Contain <strong>one special character</strong> <code>!@#$%^&*()+=\`{}</code></li>
+            <li>Be different than your previous password</li>
+          </ul>
         </div>
         <div class="g-recaptcha" data-sitekey="<%= recaptcha_site_key %>"></div>
         <input type="hidden" name="crumb" value="<%= crumb %>" />
@@ -65,4 +61,6 @@
     </div>
   </div>
 </div>
+
+<% include formassets %>
 <% include footer %>

--- a/templates/register.html
+++ b/templates/register.html
@@ -8,18 +8,27 @@
       <div class="page-header">
         <h1 class="page-header__heading">Register a Humanitarian ID account</h1>
       </div>
+
+      <% if (typeof alert !== 'undefined') { %>
+        <div class="alert alert--inline alert--<%= alert.type %>" role="alert">
+          <div class="alert__inner">
+            <%= alert.message %>
+          </div>
+        </div>
+      <% } %>
+
       <form name="register" action="/register" method="POST" onsubmit="return checkForm(this)">
         <div class="form-field">
           <label for="email" translate>Email</label>
-          <input type="email" name="email" id="email" placeholder="you@example.com" required>
+          <input type="email" name="email" id="email" value="<%= formEmail %>" placeholder="you@example.com" required>
         </div>
         <div class="form-field">
           <label for="given_name">First Name</label>
-          <input type="text" name="given_name" id="given_name" placeholder="Your first name" required>
+          <input type="text" name="given_name" id="given_name" value="<%= formGivenName %>" placeholder="Your first name" required>
         </div>
         <div class="form-field">
           <label for="family_name">Last Name</label>
-          <input type="text" name="family_name" id="family_name" placeholder="Your last name" required>
+          <input type="text" name="family_name" id="family_name" value="<%= formFamilyName %>" placeholder="Your last name" required>
         </div>
         <div class="form-field">
           <label for="password">Password</label>


### PR DESCRIPTION
# HID-2131 / HID-2144 / HID-2145

Ok I admit this PR has scope creep, but it all had to do with password reset or registration.

- Rename `isStrongPasswordV3` to `isStrongPassword` and delete the old v2 version using that name
- Remove all the temporary business logic that checked the request URL to determine which to use
- Ensure adoption is working within HID Auth
- Frontend/text updates to HID Auth
- Used HTML5 form validation on `new_password` and `register` forms.
- Consolidated JS form validation to one include file and used on both forms.
- a few lines of CSS to support the HTML5 validation. Also within the same include file as previous bullet.
- adopted same layout on most forms
- Fixed an HTML bug on the "message" template that was breaking CD.
- Logs which user failed to reset password in ELK.
- HID-2145: Errors during registration redirect back to registration form
- HID-2144: enforce passwords having to match on server during registration