### PR TITLE
HID-2153: manage emails on profile

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1551,6 +1551,7 @@ module.exports = {
       appValidationUrl = request.payload.app_validation_url;
     }
 
+    // Is the payload complete enough to take action?
     if (!appValidationUrl || !email) {
       logger.warn(
         '[UserController->addEmail] Either email or app_validation_url was not provided',
@@ -1565,6 +1566,7 @@ module.exports = {
       throw Boom.badRequest('Required parameters not present in payload');
     }
 
+    // Is the verification link pointing to a domain in our allow-list?
     if (!HelperService.isAuthorizedUrl(appValidationUrl)) {
       logger.warn(
         `[UserController->addEmail] app_validation_url ${appValidationUrl} is not in authorizedDomains allowlist`,
@@ -1577,18 +1579,7 @@ module.exports = {
       throw Boom.badRequest('Invalid app_validation_url');
     }
 
-    // Make sure email added is unique
-    const erecord = await User.findOne({ 'emails.email': email });
-    if (erecord) {
-      logger.warn(
-        `[UserController->addEmail] Email ${email} is not unique`,
-        {
-          request,
-          fail: true,
-        },
-      );
-      throw Boom.badRequest('Email is not unique');
-    }
+    // Does the target user exist?
     const record = await User.findOne({ _id: userId });
     if (!record) {
       logger.warn(
@@ -1601,15 +1592,39 @@ module.exports = {
       throw Boom.notFound();
     }
 
+    // Make sure the email us unique to the target user's profile. Checking just
+    // the target user first allows us to display better user feedback when the
+    // request comes internally from HID Auth interface.
     if (record.emailIndex(email) !== -1) {
       logger.warn(
-        `[UserController->addEmail] Email ${email} already exists`,
+        `[UserController->addEmail] Email ${email} already belongs to ${userId}.`,
         {
           request,
           fail: true,
+          user: {
+            id: userId,
+            email: record.email,
+          },
         },
       );
       throw Boom.badRequest('Email already exists');
+    }
+
+    // Make sure email added is unique to the entire HID system.
+    const erecord = await User.findOne({ 'emails.email': email });
+    if (erecord) {
+      logger.warn(
+        `[UserController->addEmail] Email ${email} is not unique`,
+        {
+          request,
+          fail: true,
+          user: {
+            id: userId,
+            email: record.email,
+          },
+        },
+      );
+      throw Boom.badRequest('Email is not unique');
     }
 
     if (record.emails.length === 0 && record.is_ghost) {

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1712,10 +1712,18 @@ module.exports = {
    *   '404':
    *     description: Requested user not found.
    */
-  async dropEmail(request) {
-    const { id, email } = request.params;
+  async dropEmail(request, internalArgs) {
+    let userId, email;
 
-    if (!request.params.email) {
+    if (internalArgs && internalArgs.userId && internalArgs.email) {
+      userId = internalArgs.userId;
+      email = internalArgs.email;
+    } else {
+      userId = request.params.id;
+      email = request.params.email;
+    }
+
+    if (!email) {
       logger.warn(
         '[UserController->dropEmail] No email provided',
         {
@@ -1726,10 +1734,10 @@ module.exports = {
       throw Boom.badRequest();
     }
 
-    const record = await User.findOne({ _id: id });
+    const record = await User.findOne({ _id: userId });
     if (!record) {
       logger.warn(
-        `[UserController->dropEmail] User ${id} not found`,
+        `[UserController->dropEmail] User ${userId} not found`,
         {
           request,
           fail: true,
@@ -1739,7 +1747,7 @@ module.exports = {
     }
     if (email === record.email) {
       logger.warn(
-        `[UserController->dropEmail] Primary email for user ${id} can not be removed`,
+        `[UserController->dropEmail] Primary email for user ${userId} can not be removed`,
         {
           request,
           fail: true,
@@ -1767,11 +1775,12 @@ module.exports = {
     await record.save();
 
     logger.info(
-      `[UserController->dropEmail] User ${id} saved successfully`,
+      `[UserController->dropEmail] User ${userId} saved successfully`,
       {
         request,
         user: {
-          id,
+          userId,
+          email: record.email,
         },
       },
     );

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -492,9 +492,22 @@ module.exports = {
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
       return reply.redirect('/');
     }
+
+    // Load user from DB
     const user = await User.findOne({ _id: cookie.userId });
+
+    // If the cookie has an alert to display, load it into the page and erase it
+    // from the cookie.
+    let alert;
+    if (cookie.alert) {
+      alert = cookie.alert;
+      delete cookie.alert;
+      request.yar.set('session', cookie);
+    }
+
     return reply.view('profile-edit', {
       user,
+      alert,
     });
   },
 
@@ -700,7 +713,7 @@ module.exports = {
       request.yar.set('session', cookie);
 
       // Redirect to profile on success.
-      return reply.redirect('/profile');
+      return reply.redirect('/profile/edit');
     }
   },
 

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -675,7 +675,7 @@ module.exports = {
           if (thisEmail.validated) {
             // The email is eligible to be primary.
           } else {
-            reasons.push(`You selected ${thisEmail} to be your primary address, but it is not confirmed.`);
+            reasons.push(`You selected ${thisEmail.email} to be your primary address, but it is not confirmed.`);
           }
         }
       });

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -529,18 +529,17 @@ module.exports = {
     // Did we get a valid payload object?
     if (!request.payload) {
       reasons.push('There was an server error while processing the form. Please try again.');
-    }
-
-    logger.warn(
-      '[ViewController->profileEmailsSubmit] Received an empty form payload.',
-      {
-        request,
-        fail: true,
-        user: {
-          id: cookie.userId,
+      logger.warn(
+        '[ViewController->profileEmailsSubmit] Received an empty form payload.',
+        {
+          request,
+          fail: true,
+          user: {
+            id: cookie.userId,
+          },
         },
-      },
-    );
+      );
+    }
 
     // Given name must exist.
     if (typeof request.payload.given_name !== 'undefined' && request.payload.given_name !== '') {
@@ -561,7 +560,7 @@ module.exports = {
       // Display the user feedback as an alert.
       alert = {
         type: 'danger',
-        message: '<p>Your profile could not be saved.</p><ul><li>' + reasons.join('</li><li>') + '</li></ul>',
+        message: '<p>Your basic profile info could not be saved.</p><ul><li>' + reasons.join('</li><li>') + '</li></ul>',
       };
 
       // Show user the profile edit form again.
@@ -623,18 +622,17 @@ module.exports = {
     // Did we get a valid payload object?
     if (!request.payload) {
       reasons.push('There was an server error while processing the form. Please try again.');
-    }
-
-    logger.warn(
-      '[ViewController->profileEmailsSubmit] Received an empty form payload.',
-      {
-        request,
-        fail: true,
-        user: {
-          id: cookie.userId,
+      logger.warn(
+        '[ViewController->profileEmailsSubmit] Received an empty form payload.',
+        {
+          request,
+          fail: true,
+          user: {
+            id: cookie.userId,
+          },
         },
-      },
-    );
+      );
+    }
 
     //
     // The desired primary email address must already be marked as 'validated'
@@ -664,7 +662,7 @@ module.exports = {
       // Display the user feedback as an alert.
       alert = {
         type: 'danger',
-        message: '<p>Your profile could not be saved.</p><ul><li>' + reasons.join('</li><li>') + '</li></ul>',
+        message: '<p>Your email settings could not be saved.</p><ul><li>' + reasons.join('</li><li>') + '</li></ul>',
       };
 
       // Show user the profile edit form again.

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -720,10 +720,14 @@ module.exports = {
         }).then(data => {
           cookie.alert.message += `<p>A confirmation email has been sent to ${request.payload.email_new}.</p>`;
         }).catch(err => {
+          cookie.alert.type = 'danger';
+
           // Read our error and show some user feedback.
-          if (err.message.indexOf('Email is not unique') !== -1) {
-            cookie.alert.type = 'danger';
+          if (err.message && err.message.indexOf('Email already exists') !== -1) {
             cookie.alert.message = `<p>The address ${request.payload.email_new} is already added to your account.</p>`;
+          }
+          else if (err.message && err.message.indexOf('Email is not unique') !== -1) {
+            cookie.alert.message = `<p>The address ${request.payload.email_new} is already registered.</p>`;
           }
         });
       }

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -274,17 +274,23 @@ module.exports = {
   },
 
   async verify(request, reply) {
-    if (!request.query.hash && !request.query.id && !request.query.time) {
-      throw Boom.badRequest('Missing hash parameter');
+    // Do we have what we need to validate the confirmation link?
+    if (!request.query.hash || !request.query.id || !request.query.time || !request.query.emailId) {
+      throw Boom.badRequest('Missing necessary parameters');
     }
+
+    // Populate payload object.
     request.payload = {
       hash: request.query.hash,
       id: request.query.id,
       time: request.query.time,
       emailId: request.query.emailId,
     };
+
+    // Template variables.
     const registerLink = _getRegisterLink(request.query);
     const passwordLink = _getPasswordLink(request.query);
+
     try {
       await UserController.validateEmail(request);
       return reply.view('login', {

--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -203,7 +203,7 @@ input:focus:invalid {
   outline-offset: 0;
 }
 
-.form-field code {
+form code {
   display: inline-block;
   background: #eee;
   border-radius: 3px;

--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -81,6 +81,14 @@ h1, h2, h3, h4, h5 {
   background: #007faa;
 }
 
+.cd-button--danger {
+  background-color: var(--cd-highlight-red);
+}
+
+.cd-button[disabled] {
+  opacity: .666;
+}
+
 
 /**
  * Global layout

--- a/assets/css/profile-edit.css
+++ b/assets/css/profile-edit.css
@@ -58,6 +58,9 @@
 .profile__email .email__status {
   padding: 0 1em;
 }
+.profile__email .email__delete {
+  padding-left: 1em;
+}
 
 .form-actions .cd-button {
   /* we have a link styled like a back button, plus a real button. they have

--- a/assets/css/profile-edit.css
+++ b/assets/css/profile-edit.css
@@ -26,8 +26,15 @@
 .profile__emails {}
 .profile__email {
   display: flex;
-  flex-flow: row nowrap;
   align-items: center;
+  /* Wrap so when the Confirm and Delete buttons are both present
+  the second button wraps to a new line and prevents horizontal scroll. */
+  flex-wrap: wrap;
+}
+@media screen and (min-width: 720px) {
+  .profile__email {
+    flex-flow: row nowrap;
+  }
 }
 .profile__email .email__select-primary {
   flex: 0 0 3em;
@@ -48,7 +55,7 @@
   font-weight: 700;
   color: black;
 }
-.profile__email .email__delete {
+.profile__email .email__status {
   padding: 0 1em;
 }
 

--- a/assets/css/profile-edit.css
+++ b/assets/css/profile-edit.css
@@ -7,12 +7,13 @@
   flex-flow: row wrap;
   margin: 0 -1rem;
 }
-.profile--edit > * {
+.profile--edit form {
   flex: 1 0 100%;
   padding: 0 1rem;
 }
+/* on wider screens, display the two forms in two columns */
 @media screen and (min-width: 720px) {
-  .profile--edit .form-item--w50 {
+  .profile--edit form {
     flex: 1 0 40%; /* IE11 needs a smaller value than 50% */
   }
 }
@@ -28,23 +29,31 @@
   flex-flow: row nowrap;
   align-items: center;
 }
-.profile__email .email__primary {
-  flex: 0 0 2em;
+.profile__email .email__select-primary {
+  flex: 0 0 3em;
   text-align: center;
 }
 .profile__email .email__address {
-  flex: 1 0 20em;
+  flex: 0 0 20ch;
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .profile__email .email__address--unconfirmed {
   color: #444;
+  font-style: italic;
 }
 .profile__email .email__address--confirmed {
   font-weight: 700;
   color: black;
 }
+.profile__email .email__delete {
+  padding: 0 1em;
+}
 
 .form-actions .cd-button {
-  /* we have a link styled like a back button, and a real button. they have
+  /* we have a link styled like a back button, plus a real button. they have
   different line-heights due to normalize.css not resetting links */
   line-height: 1.15;
 }

--- a/assets/css/profile-edit.css
+++ b/assets/css/profile-edit.css
@@ -34,7 +34,7 @@
   text-align: center;
 }
 .profile__email .email__address {
-  flex: 0 0 20ch;
+  flex: 0 1 20ch;
   font-family: monospace;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/assets/css/user.css
+++ b/assets/css/user.css
@@ -1,0 +1,19 @@
+/**
+ * User landing page
+ */
+.lp {}
+.lp__buttons {
+  display: flex;
+  flex-flow: row wrap;
+  margin: 0 -.5rem;
+}
+.lp__buttons .cd-button {
+  flex: 1 1 100%;
+  margin: .5rem;
+}
+@media screen and (min-width: 600px) {
+  .lp__buttons .cd-button {
+    flex-basis: 25%;
+    max-width: 180px;
+  }
+}

--- a/assets/js/profile-edit.js
+++ b/assets/js/profile-edit.js
@@ -1,0 +1,6 @@
+/**
+ * Helper function to confirm an email deletion.
+ */
+function confirmDeletion (emailAddress) {
+  return window.confirm('Are you sure you want to remove' + emailAddress + ' from your profile?');
+}

--- a/config/routes.js
+++ b/config/routes.js
@@ -177,6 +177,15 @@ module.exports = [
   },
 
   {
+    method: 'POST',
+    path: '/profile/edit/emails',
+    handler: ViewController.profileEmailsSubmit,
+    options: {
+      auth: false,
+    },
+  },
+
+  {
     method: 'GET',
     path: '/settings',
     handler: ViewController.settings,

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -31,6 +31,7 @@
           <div class="form-item [ flow ]">
             <h2>Manage email addresses</h2>
             <p>Use the radio buttons to select a new primary email address. You may only select an address which has already been confirmed.</p>
+            <p>Clicking <code aria-label="the Confirm button">[CONFIRM]</code> will re-send the confirmation email with a one-time link. After confirming, you can set that email address as your primary.</p>
 
             <% user.emails.forEach(function(thisEmail) { %>
               <div class="profile__email email">
@@ -48,7 +49,9 @@
                   <% } %>
                 </div>
                 <div class="email__status">
-                  <em><%= thisEmail.validated ? '' : 'unconfirmed' %></em>
+                  <% if (!thisEmail.validated) { %>
+                    <button type="submit" name="email_confirm" value="<%= thisEmail.email %>" class="cd-button cd-button--small cd-button--outline cd-button--bold cd-button--uppercase">Confirm</button>
+                  <% } %>
                 </div>
               </div>
             <% }) %>

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -42,9 +42,9 @@
                 </div>
                 <div class="email__delete">
                   <% if (user.email === thisEmail.email) { %>
-                    <button disabled type="submit" value="<%= thisEmail.email %>" class="cd-button cd-button--small cd-button--bold cd-button--uppercase">Primary</button>
+                    <button disabled class="cd-button cd-button--small cd-button--bold cd-button--uppercase">Primary</button>
                   <% } else { %>
-                    <button type="submit" value="<%= thisEmail.email %>" class="cd-button cd-button--small cd-button--bold cd-button--uppercase cd-button--danger">Delete</button>
+                    <button type="submit" name="email_delete" value="<%= thisEmail.email %>" class="cd-button cd-button--small cd-button--bold cd-button--uppercase cd-button--danger">Delete</button>
                   <% } %>
                 </div>
                 <div class="email__status">

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -3,46 +3,68 @@
 
 <div class="api-page">
   <main role="main" id="main-content" class="cd-container">
-    <div class="cd-layout-content">
+    <div class="cd-layout-content [ flow ]">
+      <h1 class="page-header__heading">Edit profile</h1>
       <% include alert.html %>
-      <form action="/profile/edit" method="POST" class="profile profile--edit [ flow ]">
-        <h1 class="page-header__heading">Edit profile</h1>
+      <div class="profile profile--edit">
 
-
-        <div class="form-item form-item--w50">
-          <label for="profile-given_name">Given Name:</label>
-          <input type="text" id="profile-given_name" name="given_name" value="<%= user.given_name %>" required>
-        </div>
-        <div class="form-item form-item--w50">
-          <label for="profile-family_name">Family name:</label>
-          <input type="text" id="profile-family_name" name="family_name" value="<%= user.family_name %>" required>
-        </div>
-        <div class="form-item [ flow ]">
-          <h3>Manage email addresses:</h3>
-          <p>Use the radio buttons to select a new primary email address. You may only select an address which has already been confirmed.</p>
-
-          <% user.emails.forEach(function(thisEmail) { %>
-            <div class="profile__email email">
-              <div class="email__primary">
-                <input type="radio" name="email_primary" id="email_primary-<%= thisEmail._id.toString() %>" value="<%= thisEmail.email %>" <%= user.email === thisEmail.email ? 'checked' : '' %> <%= thisEmail.validated ? '' : 'disabled' %>>
-              </div>
-              <div>
-                <label for="email_primary-<%= thisEmail._id.toString() %>" class="email__address <%= !thisEmail.validated ? 'email__address--unconfirmed' : 'email__address--confirmed' %>"><%= thisEmail.email %></label>
-                <span class="email__status"><%= thisEmail.validated ? '' : 'unconfirmed' %></span>
-              </div>
-            </div>
-          <% }) %>
-
-          <h3>Add a new email address:</h3>
-          <div class="profile__new-email">
-            <input type="email" name="email_new" id="email_new" placeholder="you@example.com" title="Must be a valid email address. You are not required to fill this field.">
+        <form action="/profile/edit" method="POST" class="[ flow ]">
+          <div class="form-item">
+            <h2>Manage basic info</h2>
+            <p>You are required to provide your family name and given name.</p>
           </div>
-        </div>
-        <div class="form-actions">
-          <button type="submit" class="cd-button cd-button--bold cd-button--uppercase">Save Profile</button>
-          <a href="/profile" class="cd-button cd-button--uppercase cd-button--outline">Cancel</a>
-        </div>
-      </form>
+          <div class="form-item">
+            <label for="profile-given_name">Given Name:</label>
+            <input type="text" id="profile-given_name" name="given_name" value="<%= user.given_name %>" required>
+          </div>
+          <div class="form-item">
+            <label for="profile-family_name">Family name:</label>
+            <input type="text" id="profile-family_name" name="family_name" value="<%= user.family_name %>" required>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="cd-button cd-button--bold cd-button--uppercase">Update Name</button>
+            <a href="/profile" class="cd-button cd-button--uppercase cd-button--outline">Cancel</a>
+          </div>
+        </form>
+
+        <form action="/profile/edit/emails" method="POST" class="[ flow ]">
+          <div class="form-item [ flow ]">
+            <h2>Manage email addresses</h2>
+            <p>Use the radio buttons to select a new primary email address. You may only select an address which has already been confirmed.</p>
+
+            <% user.emails.forEach(function(thisEmail) { %>
+              <div class="profile__email email">
+                <div class="email__select-primary">
+                  <input type="radio" name="email_primary" id="email_primary-<%= thisEmail._id.toString() %>" value="<%= thisEmail.email %>" <%= user.email === thisEmail.email ? 'checked' : '' %> <%= thisEmail.validated ? '' : 'disabled' %>>
+                </div>
+                <div class="email__address">
+                  <label for="email_primary-<%= thisEmail._id.toString() %>" class="<%= !thisEmail.validated ? 'email__address--unconfirmed' : 'email__address--confirmed' %>"><%= thisEmail.email %></label>
+                </div>
+                <div class="email__delete">
+                  <% if (user.email === thisEmail.email) { %>
+                    <button disabled type="submit" value="<%= thisEmail.email %>" class="cd-button cd-button--small cd-button--bold cd-button--uppercase">Primary</button>
+                  <% } else { %>
+                    <button type="submit" value="<%= thisEmail.email %>" class="cd-button cd-button--small cd-button--bold cd-button--uppercase cd-button--danger">Delete</button>
+                  <% } %>
+                </div>
+                <div class="email__status">
+                  <em><%= thisEmail.validated ? '' : 'unconfirmed' %></em>
+                </div>
+              </div>
+            <% }) %>
+
+            <h3>Add a new email address:</h3>
+            <div class="profile__new-email">
+              <input type="email" name="email_new" id="email_new" placeholder="you@example.com" title="Must be a valid email address. You are not required to fill this field.">
+            </div>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="cd-button cd-button--bold cd-button--uppercase">Update email</button>
+            <a href="/profile" class="cd-button cd-button--uppercase cd-button--outline">Cancel</a>
+          </div>
+        </form>
+
+      </div>
     </div>
   </main>
 </div>

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -27,7 +27,7 @@
           </div>
         </form>
 
-        <form action="/profile/edit/emails" method="POST" class="[ flow ]">
+        <form name="emailForm" action="/profile/edit/emails" method="POST" class="[ flow ]">
           <div class="form-item [ flow ]">
             <h2>Manage email addresses</h2>
             <p>Use the radio buttons to select a new primary email address. You may only select an address which has already been confirmed.</p>
@@ -45,7 +45,15 @@
                   <% if (user.email === thisEmail.email) { %>
                     <button disabled class="cd-button cd-button--small cd-button--bold cd-button--uppercase">Primary</button>
                   <% } else { %>
-                    <button type="submit" name="email_delete" value="<%= thisEmail.email %>" class="cd-button cd-button--small cd-button--bold cd-button--uppercase cd-button--danger">Delete</button>
+                    <button
+                      type="submit"
+                      name="email_delete"
+                      value="<%= thisEmail.email %>"
+                      class="cd-button cd-button--small cd-button--bold cd-button--uppercase cd-button--danger"
+                      onclick="return confirmDeletion('<%= thisEmail.email %>')"
+                    >
+                      Delete
+                    </button>
                   <% } %>
                 </div>
                 <div class="email__status">
@@ -71,4 +79,6 @@
     </div>
   </main>
 </div>
+
+<script><% include ../assets/js/profile-edit.js %></script>
 <% include footer %>

--- a/templates/totp.html
+++ b/templates/totp.html
@@ -25,7 +25,7 @@
         <input type="hidden" name="crumb" value="<%= crumb %>" />
 
         <div class="form-field">
-          <button type="submit" class="btn-primary btn-block">
+          <button type="submit" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
             Verify
           </button>
         </div>

--- a/templates/user.html
+++ b/templates/user.html
@@ -1,16 +1,17 @@
 <% include header %>
-<div class="api-page">
-  <main role="main" id="main-content" class="cd-container">
-    <div class="cd-layout-content [ flow ]">
-      <h1 class="page-header__heading">Welcome, <%= user.name %></h1>
-      <p class="form-field">You are logged in to HID.</p>
+<style><% include ../assets/css/user.css %></style>
 
-      <p>
-        <a href="/profile" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">Profile</a>
-        <a href="/settings" class="cd-button cd-button--outline cd-button--wide cd-button--uppercase">Settings</a>
-        <a href="/logout" class="cd-button cd-button--outline cd-button--wide cd-button--uppercase">Logout</a>
-      </p>
-    </div>
-  </main>
-</div>
+<main role="main" id="main-content" class="cd-container">
+  <div class="cd-layout-content lp [ flow ]">
+    <h1 class="page-header__heading">Welcome, <%= user.name %></h1>
+    <p class="form-field">You are logged in to HID.</p>
+
+    <p class="lp__buttons [ flow ]">
+      <a href="/profile" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">Profile</a>
+      <a href="/settings" class="cd-button cd-button--outline cd-button--wide cd-button--uppercase">Settings</a>
+      <a href="/logout" class="cd-button cd-button--outline cd-button--wide cd-button--uppercase">Logout</a>
+    </p>
+  </div>
+</main>
+
 <% include footer %>

--- a/templates/user.html
+++ b/templates/user.html
@@ -3,9 +3,13 @@
   <main role="main" id="main-content" class="cd-container">
     <div class="cd-layout-content [ flow ]">
       <h1 class="page-header__heading">Welcome, <%= user.name %></h1>
-      <p class="form-field">You are now logged in.</p>
+      <p class="form-field">You are logged in to HID.</p>
 
-      <p><a href="/logout" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">Logout</a></p>
+      <p>
+        <a href="/profile" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">Profile</a>
+        <a href="/settings" class="cd-button cd-button--outline cd-button--wide cd-button--uppercase">Settings</a>
+        <a href="/logout" class="cd-button cd-button--outline cd-button--wide cd-button--uppercase">Logout</a>
+      </p>
     </div>
   </main>
 </div>


### PR DESCRIPTION
# HID-2153

This branch finishes the profile management section by allowing all aspects of emails to be managed from one screen:

- Add a new email to your profile
- Re-send an email confirmation to unconfirmed addresses
- Delete an email from your profile

I tried to be very thorough in validating form submissions even to the point of editing the DOM and getting around the basic client-side validations. If you can find a way to break it I will be very interested to see what you come up with.

- Trying to set an email as primary with the radio button, then click <kbd>DELETE</kbd> on that same email address
- Edit DOM to send confirmations to confirmed emails
- Edit DOM to delete primary address
- Edit DOM to set an unconfirmed address as primary

I had to tweak the internals of several functions but tested them along the way. I retested each individual endpoint, in addition to all the ones which require multiple steps (e.g. firing API call to generate confirmation email => clicking email). Some other tweaks were done to support the UX of our profile editing screens.

- The error discovered in #171 about "this email is already on your account" has been addressed — we differentiate between ones on your profile, and when another HID user has claimed an email. No new info is surfaced by doing this. The API was already outputting this info.
- If a user session is detected when confirmation links are clicked, it no longer forces you to log in again. It redirects to your profile so that people clicking <kbd>CONFIRM</kbd> then returning via email will see the same page.

I added a few more buttons to the user landing page so all their options are spelled out for them.

I did test in Safari, Chrome, FF, and IE11. Happy to have another pair of 👀 regardless.
