### PR TITLE
HID-2009: manage oauth clients on user profile

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -2565,6 +2565,17 @@ module.exports = {
    * tags:
    *   - user
    * summary: Revokes one OAuth Client from a user's profile.
+   * parameters:
+   *   - name: id
+   *     in: path
+   *     description: The user ID
+   *     required: true
+   *     type: string
+   *   - name: client
+   *     in: path
+   *     description: The OAuth Client ID
+   *     required: true
+   *     type: string
    * responses:
    *   '200':
    *     description: OAuth Client revoked successfully. Returns user object.

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -2687,6 +2687,8 @@ module.exports = {
           stack_trace: err.stack,
         },
       );
+
+      throw Boom.internal('Internal server error.');
     }
   },
 };

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -866,11 +866,19 @@ module.exports = {
       // No validation errors.
       // Perform DB operation and provide user feedback.
       const revokedClient = user.authorizedClients.filter(client => client._id.toString() === request.payload.oauth_client_delete)[0];
-      alert.type = 'success';
-      alert.message = `
-        <p>You successfully revoked <strong>${revokedClient.name}</strong> from your profile.</p>
-        <p>If you wish to restore access just log into that website again using HID.</p>
-      `;
+      await UserController.revokeOauthClient({}, {
+        userId: cookie.userId,
+        clientId: request.payload.oauth_client_delete,
+      }).then(data => {
+        alert.type = 'success';
+        alert.message = `
+          <p>You successfully revoked <strong>${revokedClient.name}</strong> from your profile.</p>
+          <p>If you wish to restore access you can log into that website again using HID.</p>
+        `;
+      }).catch(err => {
+        alert.type = 'danger';
+        alert.message = err.message;
+      });
     }
 
     // Set user feedback in cookie.

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -836,8 +836,6 @@ module.exports = {
     let reasons = [];
     let alert = {};
 
-    console.log('🐛', request.payload);
-
     // Did they try to delete an OAuth client?
     if (request.payload && request.payload.oauth_client_delete) {
       // TODO: if we can, pull this from a canonical source. This was copied

--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -28,6 +28,20 @@
 
   /* darken */
   --cd-primary-color--dark: hsl(var(--cd-primary-color-h), var(--cd-primary-color-s), calc(var(--cd-primary-color-l) - 26%));
+
+  /**
+   * Adopt the CD colors for alerts
+   *
+   * @see https://feature.commondesign-unocha-org.ahconu.org/demo#cd-alert
+   */
+  --cd-red: #cd3a1f;
+  --cd-red--light: #f8d8d3;
+  --cd-orange: #db7b18;
+  --cd-orange--light: #fae6d1;
+  --cd-yellow: #d5de26;
+  --cd-yellow--light: #f7f8d3;
+  --cd-green: #7fb92f;
+  --cd-green--light: #e8f5d6;
 }
 
 /**
@@ -129,23 +143,30 @@ a:focus {
  * Alerts and other messages can appear on any page, so we'll define them here.
  */
 .alert {
-  padding: 1em;
-  background-color: #eee;
-}
-
-.alert--danger {
-  color: #474747;
-  background-color: #F4AEB0;
+  padding: 1rem;
+  margin: 1rem 0 2rem;
+  border: 1px solid var(--cd-blue--bright);
+  border-radius: 0.25rem;
+  box-shadow: -8px 0 0 var(--cd-blue--bright);
+  color: var(--cd-grey--dark);
 }
 
 .alert--success {
-  background-color: #E5F3F6;
-  color: #295A78;
+  background-color: var(--cd-green--light);
+  border: 1px solid var(--cd-green);
+  box-shadow: -8px 0 0 var(--cd-green);
 }
 
 .alert--warning {
-  background-color: #E5F3F6;
-  color: #295A78;
+  background-color: var(--cd-orange--light);
+  border: 1px solid var(--cd-orange);
+  box-shadow: -8px 0 0 var(--cd-orange);
+}
+
+.alert--danger {
+  background-color: var(--cd-red--light);
+  border: 1px solid var(--cd-red);
+  box-shadow: -8px 0 0 var(--cd-red);
 }
 
 .alert p {

--- a/assets/css/user-settings.css
+++ b/assets/css/user-settings.css
@@ -33,7 +33,7 @@
   padding: 1.5rem;
 }
 
-[role="tabpanel"] * + * {
+[role="tabpanel"] > * + * {
   margin-top: 0.75rem;
 }
 

--- a/assets/css/user-settings.css
+++ b/assets/css/user-settings.css
@@ -69,3 +69,30 @@
     border-top: 0;
   }
 }
+
+
+/**
+ * OAuth authorized clients list
+ */
+.oauth-clients-list {
+  margin: 0;
+  padding: 0;
+}
+
+.oac {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+}
+
+.oac__delete {
+  flex: 0 0 4rem;
+  text-align: center;
+}
+
+.oac__delete .cd-icon--cancel {
+  fill: white;
+}
+
+.oac__name {
+}

--- a/assets/js/confirmation.js
+++ b/assets/js/confirmation.js
@@ -1,0 +1,6 @@
+/**
+ * Helper function to confirm an email deletion.
+ */
+function confirmDeletion (identifier) {
+  return window.confirm('Are you sure you want to remove ' + identifier + ' from your profile?');
+}

--- a/assets/js/profile-edit.js
+++ b/assets/js/profile-edit.js
@@ -1,6 +1,0 @@
-/**
- * Helper function to confirm an email deletion.
- */
-function confirmDeletion (emailAddress) {
-  return window.confirm('Are you sure you want to remove' + emailAddress + ' from your profile?');
-}

--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -1,0 +1,74 @@
+/* https://inclusive-components.design/tabbed-interfaces */
+(function iife() {
+  // Get relevant elements and collections
+  const tabbed = document.querySelector('.tabbed');
+  const tablist = tabbed.querySelector('ul');
+  const tabs = tablist.querySelectorAll('a');
+  const panels = tabbed.querySelectorAll('[id^="section"]');
+
+  // The tab switching function
+  const switchTab = (oldTab, newTab) => {
+    newTab.focus();
+    // Make the active tab focusable by the user (Tab key)
+    newTab.removeAttribute('tabindex');
+    // Set the selected state
+    newTab.setAttribute('aria-selected', 'true');
+    oldTab.removeAttribute('aria-selected');
+    oldTab.setAttribute('tabindex', '-1');
+    // Get the indices of the new and old tabs to find the correct
+    // tab panels to show and hide
+    let index = Array.prototype.indexOf.call(tabs, newTab);
+    let oldIndex = Array.prototype.indexOf.call(tabs, oldTab);
+    panels[oldIndex].hidden = true;
+    panels[index].hidden = false;
+  };
+
+  // Add the tablist role to the first <ul> in the .tabbed container
+  tablist.setAttribute('role', 'tablist');
+
+  // Add semantics are remove user focusability for each tab
+  Array.prototype.forEach.call(tabs, (tab, i) => {
+    tab.setAttribute('role', 'tab');
+    tab.setAttribute('id', 'tab' + (i + 1));
+    tab.setAttribute('tabindex', '-1');
+    tab.parentNode.setAttribute('role', 'presentation');
+
+    // Handle clicking of tabs for mouse users
+    tab.addEventListener('click', e => {
+      e.preventDefault();
+      let currentTab = tablist.querySelector('[aria-selected]');
+      if (e.currentTarget !== currentTab) {
+        switchTab(currentTab, e.currentTarget);
+      }
+    });
+
+    // Handle keydown events for keyboard users
+    tab.addEventListener('keydown', e => {
+      // Get the index of the current tab in the tabs node list
+      let index = Array.prototype.indexOf.call(tabs, e.currentTarget);
+      // Work out which key the user is pressing and
+      // Calculate the new tab's index where appropriate
+      let dir = e.which === 37 ? index - 1 : e.which === 39 ? index + 1 : e.which === 40 ? 'down' : null;
+      if (dir !== null) {
+        e.preventDefault();
+        // If the down key is pressed, move focus to the open panel,
+        // otherwise switch to the adjacent tab
+        dir === 'down' ? panels[i].focus() : tabs[dir] ? switchTab(e.currentTarget, tabs[dir]) : void 0;
+      }
+    });
+  });
+
+  // Add tab panel semantics and hide them all
+  Array.prototype.forEach.call(panels, (panel, i) => {
+    panel.setAttribute('role', 'tabpanel');
+    panel.setAttribute('tabindex', '-1');
+    let id = panel.getAttribute('id');
+    panel.setAttribute('aria-labelledby', tabs[i].id);
+    panel.hidden = true;
+  });
+
+  // Initially activate the first tab and reveal the first tab panel
+  tabs[0].removeAttribute('tabindex');
+  tabs[0].setAttribute('aria-selected', 'true');
+  panels[0].hidden = false;
+})();

--- a/config/routes.js
+++ b/config/routes.js
@@ -726,6 +726,24 @@ module.exports = [
   },
 
   {
+    method: 'DELETE',
+    path: '/api/v3/user/{id}/clients/{client}',
+    options: {
+      pre: [
+        UserPolicy.canUpdate,
+      ],
+      handler: UserController.revokeOauthClient,
+      validate: {
+        params: Joi.object({
+          id: Joi.string().regex(objectIdRegex),
+          client: Joi.string().regex(objectIdRegex),
+        }),
+      },
+    },
+  },
+
+
+  {
     method: 'POST',
     path: '/api/v2/user/{id}/phone_numbers',
     options: {

--- a/config/routes.js
+++ b/config/routes.js
@@ -195,6 +195,15 @@ module.exports = [
   },
 
   {
+    method: 'POST',
+    path: '/settings/oauth-clients',
+    handler: ViewController.settingsOauthSubmit,
+    options: {
+      auth: false,
+    },
+  },
+
+  {
     method: 'GET',
     path: '/docs/{param*}',
     handler: {

--- a/docs/v3/hid.yml
+++ b/docs/v3/hid.yml
@@ -907,4 +907,18 @@ paths:
         '400':
           description: Bad request. See response body for details.
       security: []
+  '/user/{id}/clients/{client}':
+    delete:
+      tags:
+        - user
+      summary: Revokes one OAuth Client from a user's profile.
+      responses:
+        '200':
+          description: OAuth Client revoked successfully. Returns user object.
+        '400':
+          description: Bad request. See response body for details.
+        '401':
+          description: Requesting user lacks permission to view requested user.
+        '404':
+          description: Requested user not found.
 

--- a/docs/v3/hid.yml
+++ b/docs/v3/hid.yml
@@ -912,6 +912,17 @@ paths:
       tags:
         - user
       summary: Revokes one OAuth Client from a user's profile.
+      parameters:
+        - name: id
+          in: path
+          description: The user ID
+          required: true
+          type: string
+        - name: client
+          in: path
+          description: The OAuth Client ID
+          required: true
+          type: string
       responses:
         '200':
           description: OAuth Client revoked successfully. Returns user object.

--- a/templates/footer.ejs
+++ b/templates/footer.ejs
@@ -28,7 +28,7 @@
             <svg class="cd-icon cd-icon--github" width="32" height="32" aria-hidden="true" focusable="false">
               <use xlink:href="#cd-icon--sm-gh-def"></use>
             </svg>
-            <svg class="cd-icon cd-icon--github hover-style">
+            <svg class="cd-icon cd-icon--github hover-style" aria-hidden="true" focusable="false">
               <use xlink:href="#cd-icon--sm-gh-full"></use>
             </svg>
           </a>

--- a/templates/footer.ejs
+++ b/templates/footer.ejs
@@ -25,7 +25,7 @@
         <div class="cd-footer__section cd-footer__section--social">
           <a href="https://github.com/UN-OCHA" class="cd-footer-social__link">
             <span class="element-invisible">Github</span>
-            <svg class="cd-icon cd-icon--github">
+            <svg class="cd-icon cd-icon--github" width="32" height="32" aria-hidden="true" focusable="false">
               <use xlink:href="#cd-icon--sm-gh-def"></use>
             </svg>
             <svg class="cd-icon cd-icon--github hover-style">
@@ -49,7 +49,7 @@
             <span class="cd-footer-copyright__text">Except where otherwise noted, content on this site is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0</a> International license.</span>
             <a class="cd-footer-copyright__link" href="https://creativecommons.org/licenses/by/4.0/">
               <span class="element-invisible">Creative Commons BY 4.0</span>
-              <svg class="cd-icon cd-icon--cc">
+              <svg class="cd-icon cd-icon--cc" width="32" height="32" aria-hidden="true" focusable="false">
                 <use xlink:href="#cd-icon--creative-commons"></use>
               </svg>
             </a>

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -80,5 +80,5 @@
   </main>
 </div>
 
-<script><% include ../assets/js/profile-edit.js %></script>
+<script><% include ../assets/js/confirmation.js %></script>
 <% include footer %>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -220,39 +220,6 @@
   //   return sorted.sort((a, b) => a.name.localeCompare(b.name));
   // }
 
-  // function asyncData({ route, app: { $hid } }) {
-  //   // URL pattern: /settings/:slug
-  //   const currentTab = '/settings/clients';
-  //
-  //   // Get latest user account data.
-  //   const profile = await $hid.$get('/account.json');
-  //
-  //   return {
-  //     profile,
-  //     currentTab,
-  //   };
-  // }
-
-  // function removeThisClient(idToBeRemoved) {
-  //   // Isolate client to be removed so we can prompt user for confirmation.
-  //   const clientToBeRemoved = this.profile.authorizedClients.filter(client => client._id === idToBeRemoved).pop();
-  //   const removalMessage = `Are you sure you want to remove ${clientToBeRemoved.name}? You will need to authorize the application again to access it through Humanitarian ID.`;
-  //
-  //   // Prompt user to confirm removal.
-  //   const userConfirmedRemoval = await this.$confirm(removalMessage);
-  //
-  //   // If they confirmed, then proceed with removal.
-  //   if (userConfirmedRemoval) {
-  //     // Remove client from the user's profile
-  //     const remainingClients = this.profile.authorizedClients.filter(client => client._id !== idToBeRemoved);
-  //     this.profile.authorizedClients = remainingClients;
-  //
-  //     // Update HID API
-  //     this.$hid.$put(`/api/v2/user/${this.me}`, this.profile);
-  //   }
-  // }
-
-
   function deleteAccount(totpToken) {
     // This value should only last as long as the function executes.
     let confirmed = false;

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -4,27 +4,27 @@
 <div class="api-page">
   <main role="main" id="main-content" class="cd-container">
     <div class="cd-layout-content">
-      <h1 class="page-header__heading" translate>Settings for <%= user.name %></h1>
+      <h1 class="page-header__heading">Settings for <%= user.name %></h1>
       <div class="tabbed">
         <ul>
 <!--          <li> -->
-<!--            <a href="#section-password" translate>Password</a>-->
+<!--            <a href="#section-password">Password</a>-->
 <!--          </li>-->
           <li>
-            <a href="#section-apps" translate>Authorized Apps</a>
+            <a href="#section-apps">Authorized Apps</a>
           </li>
 <!--          <li>-->
-<!--            <a href="#section-security" translate>Security</a>-->
+<!--            <a href="#section-security">Security</a>-->
 <!--          </li>-->
 <!--          <li>-->
-<!--            <a href="#section-delete" translate>Delete Account</a>-->
+<!--            <a href="#section-delete">Delete Account</a>-->
 <!--          </li>-->
         </ul>
 
 <!--        <section id="section-password">-->
-<!--          <h2 translate>Change Password</h2>-->
+<!--          <h2>Change Password</h2>-->
 <!--          <form onsubmit="changePassword()">-->
-<!--              <p translate>You must enter your current password to set a new password.</p>-->
+<!--              <p>You must enter your current password to set a new password.</p>-->
 <!--              <input-->
 <!--                id="current-password"-->
 <!--                name="password"-->
@@ -35,7 +35,7 @@
 <!--                outlined-->
 <!--                required-->
 <!--              />-->
-<!--              <p translate>Passwords must be <strong>at least {{ $v.password.$params.minLength.min }} characters long</strong>, contain at least <strong>one number</strong>, <strong>one uppercase character</strong>, <strong>one lowercase character</strong>, and one <strong>special character: <code>!@#$%^&*()+=\`{}</code></strong>. Password has to be different than your previous one.</p>-->
+<!--              <p>Passwords must be <strong>at least {{ $v.password.$params.minLength.min }} characters long</strong>, contain at least <strong>one number</strong>, <strong>one uppercase character</strong>, <strong>one lowercase character</strong>, and one <strong>special character: <code>!@#$%^&*()+=\`{}</code></strong>. Password has to be different than your previous one.</p>-->
 <!--              <input-->
 <!--                id="new-password"-->
 <!--                name="password"-->
@@ -70,7 +70,7 @@
         <section id="section-apps">
           <h2>Authorized Apps</h2>
           <div class="alert alert--warning alert--inline" role="alert">
-            <div class="alert__inner" translate>
+            <div class="alert__inner">
               Currently you cannot revoke access to applications.<br>
               Work is in progress to offer this option.
             </div>
@@ -94,25 +94,25 @@
         </section>
 
 <!--        <section id="section-security">-->
-<!--          <h2 translate>Two-factor authentication</h2>-->
+<!--          <h2>Two-factor authentication</h2>-->
 <!--          <% if (user.totp) { %>-->
-<!--          <span class="status" style="color: #777;" translate>Status: <em>Enabled</em></span>-->
+<!--          <span class="status" style="color: #777;">Status: <em>Enabled</em></span>-->
 <!--          <p>&nbsp;</p>-->
 <!--          <button class="cd-button cd-button&#45;&#45;style cd-button&#45;&#45;dectivate" onclick="goTo('deactivate');">-->
 <!--            Deactivate-->
 <!--          </button>-->
 <!--          <%} else { %>-->
-<!--            <span class="status" style="color: #777;" translate>Status: <em>Disabled</em></span>-->
-<!--            <p translate>Two-factor authentication is an effective way to protect your account from unauthorized access. What you need to do to enable this feature:</p>-->
+<!--            <span class="status" style="color: #777;">Status: <em>Disabled</em></span>-->
+<!--            <p>Two-factor authentication is an effective way to protect your account from unauthorized access. What you need to do to enable this feature:</p>-->
 <!--            <ol>-->
-<!--              <li translate>If you don't have one yet, download an authenticator app (e.g. the Google Authenticator - <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en_GB" target="_blank" rel="noopener">Play Store</a>, <a href="https://itunes.apple.com/us/app/google-authenticator/id388497605?mt=8" target="_blank" rel="noopener">App Store</a>).</li>-->
-<!--              <li translate>Then click on the Activate button below</li>-->
-<!--              <li translate>After you have activated the Two-factor verification on this page you will see a QR-code that you need to scan with your authenticator app or you do the set-up manually.</li>-->
-<!--              <li translate>You'll then be sent a code to your mobile authenticator app.</li>-->
+<!--              <li>If you don't have one yet, download an authenticator app (e.g. the Google Authenticator - <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en_GB" target="_blank" rel="noopener">Play Store</a>, <a href="https://itunes.apple.com/us/app/google-authenticator/id388497605?mt=8" target="_blank" rel="noopener">App Store</a>).</li>-->
+<!--              <li>Then click on the Activate button below</li>-->
+<!--              <li>After you have activated the Two-factor verification on this page you will see a QR-code that you need to scan with your authenticator app or you do the set-up manually.</li>-->
+<!--              <li>You'll then be sent a code to your mobile authenticator app.</li>-->
 <!--            </ol>-->
-<!--            <p translate>Two-factor authentication is an optional security feature. Once enabled, Humanitarian ID will require a six-digit security code or a security key in addition to your password if you wish to login or change your password. You can also set a device as trusted during login, you will then not be asked a seperate code on this device.</p>-->
-<!--            <p translate>After enabling two-factor authentication, you'll receive 16 backup codes. Copy these codes or download them and store them securely. Once a backup code is used, it can't be used again.</p>-->
-<!--            <p translate>You can remove the two-factor authentication at any point by clicking on ‘Deactivate’ button.</p>-->
+<!--            <p>Two-factor authentication is an optional security feature. Once enabled, Humanitarian ID will require a six-digit security code or a security key in addition to your password if you wish to login or change your password. You can also set a device as trusted during login, you will then not be asked a seperate code on this device.</p>-->
+<!--            <p>After enabling two-factor authentication, you'll receive 16 backup codes. Copy these codes or download them and store them securely. Once a backup code is used, it can't be used again.</p>-->
+<!--            <p>You can remove the two-factor authentication at any point by clicking on ‘Deactivate’ button.</p>-->
 <!--            <button class="cd-button cd-button&#45;&#45;style cd-button&#45;&#45;activate" onclick="requestTotpConfig();">-->
 <!--              Activate-->
 <!--            </button>-->
@@ -121,7 +121,7 @@
 <!--        </section>-->
 
 <!--        <section id="section-delete">-->
-<!--          <h2 translate>Delete Account</h2>-->
+<!--          <h2>Delete Account</h2>-->
 <!--          <button type="button" class="cd-button cd-button&#45;&#45;bold cd-button&#45;&#45;delete" onclick="deleteAccount();">-->
 <!--            Delete-->
 <!--          </button>-->

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -90,7 +90,7 @@
                       onclick="return confirmDeletion('<%= client.name %>');"
                       aria-label="Delete <%= client.name %>"
                     >
-                      <svg class="cd-icon cd-icon--cancel">
+                      <svg class="cd-icon cd-icon--cancel" width="16" height="16" aria-hidden="true" focusable="false">
                         <use xlink:href="#cd-icon--cancel"></use>
                       </svg>
                     </button>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -76,7 +76,10 @@
             <% } else { %>
             <p>You have <strong><%= user.authorizedClients.length %> websites</strong> that have been granted access to your profile.</p>
             <ul class="oauth-clients-list [ flow ]">
-              <% user.authorizedClients.forEach(function(client) { %>
+              <%
+                const sorted = user.authorizedClients.sort((a, b) => a.name.localeCompare(b.name));
+                sorted.forEach(function(client) {
+              %>
                 <li class="oauth-clients-list__client oac">
                   <span class="oac__delete">
                     <button

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -88,7 +88,7 @@
                       value="<%= client._id.toString() %>"
                       class="cd-button cd-button--small cd-button--cancel cd-button--danger"
                       onclick="return confirmDeletion('<%= client.name %>');"
-                      aria-label="Delete <%= client.name %>"
+                      aria-label="Revoke <%= client.name %>"
                     >
                       <svg class="cd-icon cd-icon--cancel" width="16" height="16" aria-hidden="true" focusable="false">
                         <use xlink:href="#cd-icon--cancel"></use>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -74,6 +74,7 @@
             <% if (user.authorizedClients.length === 0) { %>
               <p><em>You haven't authorized any websites yet. After you log in with HID on one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service.html" target="_blank" rel="noopener">Partner Sites</a> you will see it listed here.</em></p>
             <% } else { %>
+            <p>You have <strong><%= user.authorizedClients.length %> websites</strong> that have been granted access to your profile.</p>
             <ul class="oauth-clients-list [ flow ]">
               <% user.authorizedClients.forEach(function(client) { %>
                 <li class="oauth-clients-list__client oac">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -74,8 +74,8 @@
             <% if (user.authorizedClients.length === 0) { %>
               <p><em>You haven't authorized any websites yet. After you log in with HID on one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service.html" target="_blank" rel="noopener">Partner Sites</a> you will see it listed here.</em></p>
             <% } else { %>
-            <p>You have <strong><%= user.authorizedClients.length %> websites</strong> that have been granted access to your profile.</p>
-            <ul class="oauth-clients-list [ flow ]">
+              <p>You have <strong><%= user.authorizedClients.length %> websites</strong> that have been granted access to your profile.</p>
+              <ul class="oauth-clients-list [ flow ]">
               <%
                 const sorted = user.authorizedClients.sort((a, b) => a.name.localeCompare(b.name));
                 sorted.forEach(function(client) {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -86,7 +86,7 @@
                       type="submit"
                       name="oauth_client_delete"
                       value="<%= client._id.toString() %>"
-                      class="cd-button cd-button--small cd-button--cancel cd-button--danger"
+                      class="cd-button cd-button--small cd-button--danger"
                       onclick="return confirmDeletion('<%= client.name %>');"
                       aria-label="Revoke <%= client.name %>"
                     >

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -5,6 +5,7 @@
   <main role="main" id="main-content" class="cd-container">
     <div class="cd-layout-content">
       <h1 class="page-header__heading">Settings for <%= user.name %></h1>
+      <% include alert.html %>
       <div class="tabbed">
         <ul>
 <!--          <li> -->
@@ -69,30 +70,33 @@
 
         <section id="section-apps">
           <h2>Authorized Apps</h2>
-          <div class="alert alert--warning alert--inline" role="alert">
-            <div class="alert__inner">
-              <p>Currently you cannot revoke access to applications.</p>
-              <p>Work is in progress to offer this option.</p>
-            </div>
-          </div>
-          <% if (user.authorizedClients.length === 0) { %>
-            <p><em>You haven't authorized any websites yet. After you log in with HID on one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service.html" target="_blank" rel="noopener">Partner Sites</a> you will see it listed here.</em></p>
-          <% } else { %>
-          <ul class="oauth-clients-list [ flow ]">
-            <% user.authorizedClients.forEach(function(client) { %>
-              <li class="oauth-clients-list__client oac">
-                <span class="oac__delete">
-                  <button type="button" class="cd-button cd-button--small cd-button--cancel cd-button--danger">
-                    <svg class="cd-icon cd-icon--cancel">
-                      <use xlink:href="#cd-icon--cancel"></use>
-                    </svg>
-                  </button>
-                </span>
-                <span class="oac__name"><%= client.name %></span>
-              </li>
-            <% }); %>
-          </ul>
-          <% } %>
+          <form action="/settings/oauth-clients" method="POST">
+            <% if (user.authorizedClients.length === 0) { %>
+              <p><em>You haven't authorized any websites yet. After you log in with HID on one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service.html" target="_blank" rel="noopener">Partner Sites</a> you will see it listed here.</em></p>
+            <% } else { %>
+            <ul class="oauth-clients-list [ flow ]">
+              <% user.authorizedClients.forEach(function(client) { %>
+                <li class="oauth-clients-list__client oac">
+                  <span class="oac__delete">
+                    <button
+                      type="submit"
+                      name="oauth_client_delete"
+                      value="<%= client._id.toString() %>"
+                      class="cd-button cd-button--small cd-button--cancel cd-button--danger"
+                      onclick="return confirmDeletion('<%= client.name %>');"
+                      aria-label="Delete <%= client.name %>"
+                    >
+                      <svg class="cd-icon cd-icon--cancel">
+                        <use xlink:href="#cd-icon--cancel"></use>
+                      </svg>
+                    </button>
+                  </span>
+                  <span class="oac__name"><%= client.name %></span>
+                </li>
+              <% }); %>
+            </ul>
+            <% } %>
+          </form>
         </section>
 
 <!--        <section id="section-security">-->
@@ -316,3 +320,4 @@
   // }
 
 </script>
+<script><% include ../assets/js/confirmation.js %></script>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -71,26 +71,28 @@
           <h2>Authorized Apps</h2>
           <div class="alert alert--warning alert--inline" role="alert">
             <div class="alert__inner">
-              Currently you cannot revoke access to applications.<br>
-              Work is in progress to offer this option.
+              <p>Currently you cannot revoke access to applications.</p>
+              <p>Work is in progress to offer this option.</p>
             </div>
           </div>
-          <ul>
-            <%
-              user.authorizedClients.forEach(function(client) {
-            %>
-            <li>
-              <span><%= client.name %></span>
-<!--              <button type="button" class="cd-button cd-button--small cd-button--cancel" onclick="removeThisClient(client._id);">-->
-<!--                <svg class="cd-icon cd-icon--cancel">-->
-<!--                  <use xlink:href="#cd-icon--cancel"></use>-->
-<!--                </svg>-->
-<!--              </button>-->
-            </li>
-            <%
-            });
-            %>
+          <% if (user.authorizedClients.length === 0) { %>
+            <p><em>You haven't authorized any websites yet. After you log in with HID on one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service.html" target="_blank" rel="noopener">Partner Sites</a> you will see it listed here.</em></p>
+          <% } else { %>
+          <ul class="oauth-clients-list [ flow ]">
+            <% user.authorizedClients.forEach(function(client) { %>
+              <li class="oauth-clients-list__client oac">
+                <span class="oac__delete">
+                  <button type="button" class="cd-button cd-button--small cd-button--cancel cd-button--danger">
+                    <svg class="cd-icon cd-icon--cancel">
+                      <use xlink:href="#cd-icon--cancel"></use>
+                    </svg>
+                  </button>
+                </span>
+                <span class="oac__name"><%= client.name %></span>
+              </li>
+            <% }); %>
           </ul>
+          <% } %>
         </section>
 
 <!--        <section id="section-security">-->

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -140,90 +140,12 @@
     </div>
   </main>
 </div>
+
 <% include footer %>
 
+<script><% include ../assets/js/confirmation.js %></script>
+<script><% include ../assets/js/tabs.js %></script>
 <script>
-  /* https://inclusive-components.design/tabbed-interfaces */
-  (function() {
-    // Get relevant elements and collections
-    const tabbed = document.querySelector('.tabbed');
-    const tablist = tabbed.querySelector('ul');
-    const tabs = tablist.querySelectorAll('a');
-    const panels = tabbed.querySelectorAll('[id^="section"]');
-
-    // The tab switching function
-    const switchTab = (oldTab, newTab) => {
-      newTab.focus();
-      // Make the active tab focusable by the user (Tab key)
-      newTab.removeAttribute('tabindex');
-      // Set the selected state
-      newTab.setAttribute('aria-selected', 'true');
-      oldTab.removeAttribute('aria-selected');
-      oldTab.setAttribute('tabindex', '-1');
-      // Get the indices of the new and old tabs to find the correct
-      // tab panels to show and hide
-      let index = Array.prototype.indexOf.call(tabs, newTab);
-      let oldIndex = Array.prototype.indexOf.call(tabs, oldTab);
-      panels[oldIndex].hidden = true;
-      panels[index].hidden = false;
-    };
-
-    // Add the tablist role to the first <ul> in the .tabbed container
-    tablist.setAttribute('role', 'tablist');
-
-    // Add semantics are remove user focusability for each tab
-    Array.prototype.forEach.call(tabs, (tab, i) => {
-      tab.setAttribute('role', 'tab');
-      tab.setAttribute('id', 'tab' + (i + 1));
-      tab.setAttribute('tabindex', '-1');
-      tab.parentNode.setAttribute('role', 'presentation');
-
-      // Handle clicking of tabs for mouse users
-      tab.addEventListener('click', e => {
-        e.preventDefault();
-        let currentTab = tablist.querySelector('[aria-selected]');
-        if (e.currentTarget !== currentTab) {
-          switchTab(currentTab, e.currentTarget);
-        }
-      });
-
-      // Handle keydown events for keyboard users
-      tab.addEventListener('keydown', e => {
-        // Get the index of the current tab in the tabs node list
-        let index = Array.prototype.indexOf.call(tabs, e.currentTarget);
-        // Work out which key the user is pressing and
-        // Calculate the new tab's index where appropriate
-        let dir = e.which === 37 ? index - 1 : e.which === 39 ? index + 1 : e.which === 40 ? 'down' : null;
-        if (dir !== null) {
-          e.preventDefault();
-          // If the down key is pressed, move focus to the open panel,
-          // otherwise switch to the adjacent tab
-          dir === 'down' ? panels[i].focus() : tabs[dir] ? switchTab(e.currentTarget, tabs[dir]) : void 0;
-        }
-      });
-    });
-
-    // Add tab panel semantics and hide them all
-    Array.prototype.forEach.call(panels, (panel, i) => {
-      panel.setAttribute('role', 'tabpanel');
-      panel.setAttribute('tabindex', '-1');
-      let id = panel.getAttribute('id');
-      panel.setAttribute('aria-labelledby', tabs[i].id);
-      panel.hidden = true;
-    });
-
-    // Initially activate the first tab and reveal the first tab panel
-    tabs[0].removeAttribute('tabindex');
-    tabs[0].setAttribute('aria-selected', 'true');
-    panels[0].hidden = false;
-  })();
-
-
-  // function sortedClients() {
-  //   const sorted = this.profile.authorizedClients;
-  //   return sorted.sort((a, b) => a.name.localeCompare(b.name));
-  // }
-
   function deleteAccount(totpToken) {
     // This value should only last as long as the function executes.
     let confirmed = false;
@@ -291,4 +213,3 @@
   // }
 
 </script>
-<script><% include ../assets/js/confirmation.js %></script>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -59,7 +59,7 @@
 
 <!--              <button-->
 <!--                id="reset-password"-->
-<!--                class="cd-button cd-button&#45;&#45;style"-->
+<!--                class="cd-button cd-button--style"-->
 <!--                type="submit"-->
 <!--              >-->
 <!--                Reset Password-->
@@ -81,9 +81,9 @@
             %>
             <li>
               <span><%= client.name %></span>
-<!--              <button type="button" class="cd-button cd-button&#45;&#45;small cd-button&#45;&#45;cancel" onclick="removeThisClient(client._id);">-->
-<!--                <svg class="cd-icon cd-icon&#45;&#45;cancel">-->
-<!--                  <use xlink:href="#cd-icon&#45;&#45;cancel"></use>-->
+<!--              <button type="button" class="cd-button cd-button--small cd-button--cancel" onclick="removeThisClient(client._id);">-->
+<!--                <svg class="cd-icon cd-icon--cancel">-->
+<!--                  <use xlink:href="#cd-icon--cancel"></use>-->
 <!--                </svg>-->
 <!--              </button>-->
             </li>
@@ -98,7 +98,7 @@
 <!--          <% if (user.totp) { %>-->
 <!--          <span class="status" style="color: #777;">Status: <em>Enabled</em></span>-->
 <!--          <p>&nbsp;</p>-->
-<!--          <button class="cd-button cd-button&#45;&#45;style cd-button&#45;&#45;dectivate" onclick="goTo('deactivate');">-->
+<!--          <button class="cd-button cd-button--style cd-button--dectivate" onclick="goTo('deactivate');">-->
 <!--            Deactivate-->
 <!--          </button>-->
 <!--          <%} else { %>-->
@@ -113,7 +113,7 @@
 <!--            <p>Two-factor authentication is an optional security feature. Once enabled, Humanitarian ID will require a six-digit security code or a security key in addition to your password if you wish to login or change your password. You can also set a device as trusted during login, you will then not be asked a seperate code on this device.</p>-->
 <!--            <p>After enabling two-factor authentication, you'll receive 16 backup codes. Copy these codes or download them and store them securely. Once a backup code is used, it can't be used again.</p>-->
 <!--            <p>You can remove the two-factor authentication at any point by clicking on ‘Deactivate’ button.</p>-->
-<!--            <button class="cd-button cd-button&#45;&#45;style cd-button&#45;&#45;activate" onclick="requestTotpConfig();">-->
+<!--            <button class="cd-button cd-button--style cd-button--activate" onclick="requestTotpConfig();">-->
 <!--              Activate-->
 <!--            </button>-->
 <!--          <%# Steps to activate should go here #%>-->
@@ -122,7 +122,7 @@
 
 <!--        <section id="section-delete">-->
 <!--          <h2>Delete Account</h2>-->
-<!--          <button type="button" class="cd-button cd-button&#45;&#45;bold cd-button&#45;&#45;delete" onclick="deleteAccount();">-->
+<!--          <button type="button" class="cd-button cd-button--bold cd-button--delete" onclick="deleteAccount();">-->
 <!--            Delete-->
 <!--          </button>-->
 <!--        </section>-->


### PR DESCRIPTION
# HID-2009

This PR allows user's logged into HID Auth to list and revoke OAuth Clients they've authorized for their account.

## New API Endpoint

There was no method to do this internally, and the old system was relying on a JS client to manually modify the user object, then `PUT` the entire user back into the DB.

I didn't like that options, so to facilitate this action internally I created a new API endpoint:

- `DELETE /api/v3/user/{id}/clients/{client}`
- the handler is `UserController.revokeOauthClient`

@orakili if you could review this endpoint and try to break it I would very much appreciate it. There are new docs available at http://api.hid.vm/docs/v3/#/user/delete_user__id__clients__client_ when you're running the API locally.

## HID Auth UX + CD components

@left23 the remaining part is again the UX and more adoption of CD components. I've implemented another `cd-button` for the revoke button and moved the buttons all to be left of the label so that they're lined up with one another.

I also implemented `cd-alert` styles from your feature branch, but did not change much markup. I do intend to change it, but altering the markup all over the website felt like scope creep once I started, so I went with CSS-only changes. Despite its incompleteness, I am loving how it looks compared to the old styles even without all parts of `cd-alert`, namely the missing icons.

For testing the same as profile editing applies, feel free to tweak DOM and try to break it. Tell me if any of the errors sound weird. Some of them are a little vague, but I thought group discussion would improvement quicker than me sitting alone in my corner.

I also got rid of old client-side code, and moved the tabbing JS into its own file that we might easily re-use it. Eventually I intend to offer each settings tab at its own URL, and then convert the tabs to plain hyperlinks and eventually remove the need for tab JS.