### PR TITLE
HID-1970: delete account

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -415,7 +415,7 @@ module.exports = {
         return loginRedirect(request, reply);
       } catch (err) {
         const alert = {
-          type: 'danger',
+          type: 'error',
           message: err.output.payload.message,
         };
         return reply.view('totp', {
@@ -478,7 +478,7 @@ module.exports = {
         registerLink,
         passwordLink,
         alert: {
-          type: 'danger',
+          type: 'error',
           message: alertMessage,
         },
       });

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1859,8 +1859,6 @@ module.exports = {
    * security: []
    */
   async validateEmail(request) {
-    // TODO: make sure current user can do this
-
     if (request.payload.hash) {
       const record = await User.findOne({ _id: request.payload.id }).catch((err) => {
         logger.error(
@@ -1889,19 +1887,16 @@ module.exports = {
 
       // For automatic verified status.
       let domain = null;
+
       // Assign the primary address as the initial value for `email`
       //
-      // TODO: determine why we are defaulting to the user's primary email
-      // address before going and explicitly looking up the `_id` of the email
-      // actually being verified. When this code was used during HID-1965,
-      // it did not actually work until an additional "emailId" param was passed
-      // from ViewController.verify(). However, it seemed like that query param
-      // should have been necessary beforehand in order to trigger the emailRecord
-      // lookup happening here.
-      //
-      // - Why did that need to be added?
-      // - Why did it work before?
+      // This is necessary for new account registrations, which won't have the
+      // emailId parameter sent along with their confirmation link since the new
+      // account only has a single primary email address and no secondaries.
       let { email } = record;
+
+      // If we are verifying a secondary email on an existing account, we need
+      // to look up the emailId being confirmed in order to validate the hash.
       if (request.payload.emailId) {
         const emailRecord = record.emails.id(request.payload.emailId);
         if (emailRecord) {

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -1101,8 +1101,13 @@ module.exports = {
       let reasons = [];
       let destination = '/settings/delete';
 
-      // Validate form submission for non-admins.
-      if (request.payload && request.payload.primary_email && request.payload.primary_email === user.email) {
+      // Validate form submission for non-admins. There are two possibilities:
+      // - cookie.formData implies they already validated email and are submitting TOTP
+      // - otherwise check form submission and verify input
+      if (
+        cookie.formData && cookie.formData.primary_email === user.email
+        || request.payload && request.payload.primary_email && request.payload.primary_email === user.email
+      ) {
         // form was validated
       } else {
         reasons.push('Please enter your <strong>primary email address</strong> to confirm that you want to delete your account.');
@@ -1114,6 +1119,46 @@ module.exports = {
         // In this case, we want to wipe the old feedback.
         reasons = [];
         reasons.push('Admins cannot delete their accounts. Remove your own admin status before deleting the account.');
+      } else {
+        // If user is NOT admin, and form was validated, then check if 2FA is
+        // enabled and enforce.
+        if (reasons.length === 0) {
+          const token = request.payload && request.payload['x-hid-totp'];
+          await AuthPolicy.isTOTPEnabledAndValid({}, {
+            user,
+            totp: token,
+          }).then(data => {
+            // Clean up the cookie for 2FA users.
+            delete(cookie.totpPrompt);
+            delete(cookie.formData);
+          }).catch(err => {
+            // Cookie the form data so we prompt for TOTP without populating the
+            // form, potentially allowing someone to alter their previous input
+            // by editing DOM, or forcing them re-enter the email confirmation.
+            //
+            // We wrap the assignment in a conditional to allow for multiple attempts
+            // at entering the TOTP. If we blindly set the request data, a second TOTP
+            // attempt will erase formDara and set everything to empty strings.
+            cookie.totpPrompt = true;
+            if (!cookie.formData) {
+              cookie.formData = {
+                primary_email: request.payload.primary_email,
+              };
+            }
+
+            // Display error about invalid TOTP.
+            //
+            // If we made it this far, the other feedback isn't necessary, so we
+            // clear the reasons array before setting TOTP feedback.
+            reasons = [];
+            if (err.message.indexOf('Invalid') !== -1) {
+              alert.type = 'error';
+              reasons.push('Your two-factor authentication code was invalid.')
+            } else {
+              reasons.push('Enter your two-factor authentication code to delete your account.');
+            }
+          });
+        }
       }
 
       if (reasons.length > 0) {

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -1133,29 +1133,25 @@ module.exports = {
           },
         );
 
-        // Set up feedback for login page.
+        // Overwrite the existing cookie with a fresh, empty object. This will
+        // ensure that no further actions can be taken, and that even browser
+        // refreshes won't be able to re-sumbit the form.
+        request.yar.set('session', {});
+
+        // Set up user feedback.
         alert.type = 'status';
         alert.message = '<p>You have successfully deleted your account.</p>';
 
-        // Redirect to home since the account no longer exists.
-        destination = '/';
-
-        // Overwrite the existing cookie with a fresh, empty object.
-        cookie = {};
+        // Display confirmation of deletion.
+        return reply.view('message', {
+          alert,
+          isSuccess: false,
+          title: 'Account Deleted',
+        });
       }
 
-      //
-      // For now, this cannot function, so we comment out until AuthController
-      // is altered, or we find another way to display the message easily.
-      //
-      // - we could use the `message` template but preventing refreshes from
-      //   resubmitting the form would be best.
-      // - Having the login form work like other pages (by reading cookie.alert)
-      //   would also be nice.
-      //
-      // cookie.alert = alert;
-
       // Finalize cookie (feedback, TOTP status, etc.)
+      cookie.alert = alert;
       request.yar.set('session', cookie);
 
       // Always redirect, to avoid resubmitting when user refreshes browser.

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -260,7 +260,7 @@ module.exports = {
       // Render registration form.
       return reply.view('register', {
         alert: {
-          type: 'danger',
+          type: 'warning',
           message: userMessage,
         },
         query: request.query,

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -1317,7 +1317,7 @@ UserSchema.methods = {
 
   backupCodeIndex(code) {
     let index = -1;
-    let numCodes = this.totpConf && this.totpConf.backupCodes && this.totpConf.backupCodes.length;
+    let numCodes = this.totpConf && this.totpConf.backupCodes ? this.totpConf.backupCodes.length : 0;
     for (let i = 0; i < numCodes; i++) {
       if (Bcrypt.compareSync(code, this.totpConf.backupCodes[i])) {
         index = i;

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -1317,7 +1317,8 @@ UserSchema.methods = {
 
   backupCodeIndex(code) {
     let index = -1;
-    for (let i = 0; i < this.totpConf.backupCodes.length; i += 1) {
+    let numCodes = this.totpConf && this.totpConf.backupCodes && this.totpConf.backupCodes.length;
+    for (let i = 0; i < numCodes; i++) {
       if (Bcrypt.compareSync(code, this.totpConf.backupCodes[i])) {
         index = i;
       }

--- a/api/policies/AuthPolicy.js
+++ b/api/policies/AuthPolicy.js
@@ -56,8 +56,8 @@ async function isTOTPValid(user, token) {
   }
 
   // Remove backup code so it can't be reused.
-  user.totpConf.backupCodes.slice(index, 1);
-  user.markModified('totpConf');
+  user.totpConf.backupCodes.splice(index, 1);
+  user.markModified('totpConf.backupCodes');
   await user.save();
 
   logger.info(

--- a/api/policies/AuthPolicy.js
+++ b/api/policies/AuthPolicy.js
@@ -34,7 +34,10 @@ async function isTOTPValid(user, token) {
     }
     logger.warn(
       `[AuthPolicy->isTOTPValid] Invalid TOTP token ${token}`,
-      { security: true },
+      {
+        security: true,
+        fail: true,
+      },
     );
     throw Boom.unauthorized('Invalid TOTP token !', 'totp');
   }
@@ -44,18 +47,30 @@ async function isTOTPValid(user, token) {
   if (index === -1) {
     logger.warn(
       `[AuthPolicy->isTOTPValid] Invalid backup code ${token}`,
-      { security: true },
+      {
+        security: true,
+        fail: true,
+      },
     );
     throw Boom.unauthorized('Invalid backup code !', 'totp');
   }
 
-  // remove backup code so it can't be reused
+  // Remove backup code so it can't be reused.
   user.totpConf.backupCodes.slice(index, 1);
   user.markModified('totpConf');
   await user.save();
+
   logger.info(
-    `[AuthPolicy->isTOTPValid] Successfully removed backup code for user ${user.id}`,
+    `[AuthPolicy->isTOTPValid] Successfully removed a backup code for user ${user.id}`,
+    {
+      security: true,
+      user: {
+        id: user.id,
+        email: user.email,
+      },
+    },
   );
+
   return user;
 }
 

--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -45,6 +45,10 @@
 
   /* CD colours for components */
   --cd-blue-grey: #e6ecf1;
+  --cd-blue--bright: #80cbff;
+  --cd-grey--light: #f2f2f2;
+  --cd-grey--mid: #595959;
+  --cd-grey--dark: #4a4a4a;
 }
 
 /**

--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -146,6 +146,7 @@ a:focus {
  * Alerts and other messages can appear on any page, so we'll define them here.
  */
 .alert {
+  display: block;
   padding: 1rem;
   margin: 1rem 0 2rem;
   border: 1px solid var(--cd-blue--bright);
@@ -186,11 +187,13 @@ a:focus {
  * Forms
  */
 
-form .form-field > * {
+.form-field {}
+
+.form-field > * {
   display: block;
 }
 
-form .form-field > input[type="checkbox"] {
+.form-field > input[type="checkbox"] {
   display: inline-block;
 }
 

--- a/assets/css/settings-delete.css
+++ b/assets/css/settings-delete.css
@@ -1,0 +1,3 @@
+/**
+ * User settings: delete account
+ */

--- a/assets/js/totp.js
+++ b/assets/js/totp.js
@@ -3,5 +3,6 @@
  */
 (function () {
   // Immediately focus on the text input.
-  document.querySelector('#x-hid-totp').focus();
+  var totpPrompt = document.querySelector('#x-hid-totp');
+  totpPrompt && totpPrompt.focus();
 })();

--- a/config/routes.js
+++ b/config/routes.js
@@ -223,6 +223,9 @@ module.exports = [
     method: 'GET',
     path: '/settings/delete',
     handler: ViewController.settingsDelete,
+    options: {
+      auth: false,
+    },
   },
   {
     method: 'POST',

--- a/config/routes.js
+++ b/config/routes.js
@@ -228,6 +228,9 @@ module.exports = [
     method: 'POST',
     path: '/settings/delete',
     handler: ViewController.settingsDeleteSubmit,
+    options: {
+      auth: false,
+    },
   },
 
   {

--- a/config/routes.js
+++ b/config/routes.js
@@ -193,7 +193,6 @@ module.exports = [
       auth: false,
     },
   },
-
   {
     method: 'POST',
     path: '/settings/oauth-clients',
@@ -211,7 +210,6 @@ module.exports = [
       auth: false,
     },
   },
-
   {
     method: 'POST',
     path: '/settings/password',
@@ -219,6 +217,17 @@ module.exports = [
     options: {
       auth: false,
     },
+  },
+
+  {
+    method: 'GET',
+    path: '/settings/delete',
+    handler: ViewController.settingsDelete,
+  },
+  {
+    method: 'POST',
+    path: '/settings/delete',
+    handler: ViewController.settingsDeleteSubmit,
   },
 
   {

--- a/templates/alert.html
+++ b/templates/alert.html
@@ -1,5 +1,5 @@
 <% if (typeof alert !== 'undefined' && alert.type && alert.message) { %>
-  <div class="alert alert--inline alert--<%= alert.type %> [ flow ]" role="alert">
+  <div class="alert alert--<%= alert.type %> [ flow ]" role="alert">
     <div class="alert__inner">
       <%- alert.message %>
     </div>

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -9,15 +9,15 @@
       <div class="profile profile--edit">
 
         <form action="/profile/edit" method="POST" class="[ flow ]">
-          <div class="form-item">
+          <div class="form-field">
             <h2>Manage basic info</h2>
             <p>You are required to provide your family name and given name.</p>
           </div>
-          <div class="form-item">
+          <div class="form-field">
             <label for="profile-given_name">Given Name:</label>
             <input type="text" id="profile-given_name" name="given_name" value="<%= user.given_name %>" required>
           </div>
-          <div class="form-item">
+          <div class="form-field">
             <label for="profile-family_name">Family name:</label>
             <input type="text" id="profile-family_name" name="family_name" value="<%= user.family_name %>" required>
           </div>
@@ -28,7 +28,7 @@
         </form>
 
         <form name="emailForm" action="/profile/edit/emails" method="POST" class="[ flow ]">
-          <div class="form-item [ flow ]">
+          <div class="form-field [ flow ]">
             <h2>Manage email addresses</h2>
             <p>Use the radio buttons to select a new primary email address. You may only select an address which has already been confirmed.</p>
             <p>Clicking <code aria-label="the Confirm button">[CONFIRM]</code> will re-send the confirmation email with a one-time link. After confirming, you can set that email address as your primary.</p>

--- a/templates/settings-delete.html
+++ b/templates/settings-delete.html
@@ -25,6 +25,19 @@
 
         <section id="section-delete">
           <h2>Delete your HID account</h2>
+          <% if (user.is_admin) { %>
+            <div class="cd-alert cd-alert--warning">
+              <!-- <svg class="cd-icon cd-icon--alert" aria-hidden="true" focusable="false"> -->
+                <!-- <use xlink:href="#cd-icon--alert"></use> -->
+              <!-- </svg> -->
+              <div class="cd-alert__container [ flow ]">
+                <div class="cd-alert__title">Admins cannot delete their own account</div>
+                <div class="cd-alert__message">
+                  <p>Your account is marked as an Admin, so account deletion is not possible.</p>
+                </div>
+              </div>
+            </div>
+          <% } else { %>
           <form action="/settings/delete" method="POST" class="[ flow ]">
             <div class="form-field">
               <p>Deleting your account means that you will lose your access to Humanitarian ID.</p>
@@ -41,6 +54,7 @@
               </button>
             </div>
           </form>
+          <% } %>
         </section>
       </div>
     </div>

--- a/templates/settings-delete.html
+++ b/templates/settings-delete.html
@@ -23,7 +23,25 @@
           </li>
         </nav>
 
-        <section id="section-delete"></section>
+        <section id="section-delete">
+          <h2>Delete your HID account</h2>
+          <form action="/settings/delete" method="POST" class="[ flow ]">
+            <div class="form-field">
+              <p>Deleting your account means that you will lose your access to Humanitarian ID.</p>
+            </div>
+            <label for="confirm-primary-email" class="form-field alert alert--danger">
+              <div class="alert__inner [ flow ]">
+                <p>Confirm that you wish to <strong>completely delete your HID account</strong> by typing your primary email address in the field here:</p>
+                <input type="email" name="primary_email" id="confirm-primary-email" placeholder="<%= user.email %>" required pattern="<%= user.email %>" title="Your primary email: <%= user.email %>">
+              </div>
+            </label>
+            <div class="form-actions">
+              <button name="action" value="submit" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase cd-button--danger">
+                Delete Account
+              </button>
+            </div>
+          </form>
+        </section>
       </div>
     </div>
   </main>

--- a/templates/settings-delete.html
+++ b/templates/settings-delete.html
@@ -42,10 +42,12 @@
             <div class="form-field">
               <p>Deleting your account means that you will lose your access to Humanitarian ID.</p>
             </div>
-            <label for="confirm-primary-email" class="form-field alert alert--danger">
-              <div class="alert__inner [ flow ]">
-                <p>Confirm that you wish to <strong>completely delete your HID account</strong> by typing your primary email address in the field here:</p>
-                <input type="email" name="primary_email" id="confirm-primary-email" placeholder="<%= user.email %>" required pattern="<%= user.email %>" title="Your primary email: <%= user.email %>">
+            <label for="confirm-primary-email" class="form-field cd-alert cd-alert--error">
+              <div class="cd-alert__container">
+                <div class="cd-alert__message [ flow ]">
+                  <p>Confirm that you wish to <strong>completely delete your HID account</strong> by typing your primary email address in the field here:</p>
+                  <input type="email" name="primary_email" id="confirm-primary-email" placeholder="<%= user.email %>" required pattern="<%= user.email %>" title="Your primary email: <%= user.email %>">
+                </div>
               </div>
             </label>
             <div class="form-actions">

--- a/templates/settings-delete.html
+++ b/templates/settings-delete.html
@@ -25,6 +25,7 @@
 
         <section id="section-delete">
           <h2>Delete your HID account</h2>
+
           <% if (user.is_admin) { %>
             <div class="cd-alert cd-alert--warning">
               <!-- <svg class="cd-icon cd-icon--alert" aria-hidden="true" focusable="false"> -->
@@ -38,25 +39,44 @@
               </div>
             </div>
           <% } else { %>
-          <form action="/settings/delete" method="POST" class="[ flow ]">
-            <div class="form-field">
-              <p>Deleting your account means that you will lose your access to Humanitarian ID.</p>
-            </div>
-            <label for="confirm-primary-email" class="form-field cd-alert cd-alert--error">
-              <div class="cd-alert__container">
-                <div class="cd-alert__message [ flow ]">
-                  <p>Confirm that you wish to <strong>completely delete your HID account</strong> by typing your primary email address in the field here:</p>
-                  <input type="email" name="primary_email" id="confirm-primary-email" placeholder="<%= user.email %>" required pattern="<%= user.email %>" title="Your primary email: <%= user.email %>">
+
+            <form action="/settings/delete" method="POST" class="[ flow ]">
+              <% if (totpPrompt) { %>
+                <div class="form-field [ flow ]">
+                  <h3>Two-factor authentication</h3>
+                  <label for="x-hid-totp">Authentication code</label>
+                  <input
+                    type="text"
+                    name="x-hid-totp"
+                    id="x-hid-totp"
+                    autocomplete="one-time-code"
+                    placeholder="Authentication code"
+                    required>
+                  <button name="action" value="totp" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
+                    Verify
+                  </button>
                 </div>
-              </div>
-            </label>
-            <div class="form-actions">
-              <button name="action" value="submit" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase cd-button--danger">
-                Delete Account
-              </button>
-            </div>
-          </form>
-          <% } %>
+              <% } else { %>
+                <div class="form-field">
+                  <p>Deleting your account means that you will lose your access to Humanitarian ID.</p>
+                </div>
+                <label for="confirm-primary-email" class="form-field cd-alert cd-alert--error">
+                  <div class="cd-alert__container">
+                    <div class="cd-alert__message [ flow ]">
+                      <p>Confirm that you wish to <strong>completely delete your HID account</strong> by typing your primary email address in the field here:</p>
+                      <input type="email" name="primary_email" id="confirm-primary-email" placeholder="<%= user.email %>" required pattern="<%= user.email %>" title="Your primary email: <%= user.email %>">
+                    </div>
+                  </div>
+                </label>
+                <div class="form-actions">
+                  <button name="action" value="submit" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase cd-button--danger">
+                    Delete Account
+                  </button>
+                </div>
+              <% } %>
+            </form>
+
+          <% } /* user.is_admin */ %>
         </section>
       </div>
     </div>

--- a/templates/settings-delete.html
+++ b/templates/settings-delete.html
@@ -1,0 +1,35 @@
+<% include header %>
+<style><% include ../assets/css/tabs.css %></style>
+<style><% include ../assets/css/settings-delete.css %></style>
+
+<div class="api-page">
+  <main role="main" id="main-content" class="cd-container">
+    <div class="cd-layout-content">
+      <h1 class="page-header__heading">Settings for <%= user.name %></h1>
+      <% include alert.html %>
+      <div class="tabbed">
+        <ul>
+          <li>
+            <a href="/settings">Authorized Apps</a>
+          </li>
+          <li>
+            <a href="/settings/password">Password</a>
+          </li>
+<!--          <li>-->
+<!--            <a href="#section-security">Security</a>-->
+<!--          </li>-->
+          <li>
+            <a href="/settings/delete" aria-selected="true">Delete Account</a>
+          </li>
+        </ul>
+
+        <section id="section-delete"></section>
+      </div>
+    </div>
+  </main>
+</div>
+
+<% include footer %>
+
+<script><% include ../assets/js/tabs.js %></script>
+<script><% include ../assets/js/totp.js %></script>

--- a/templates/settings-delete.html
+++ b/templates/settings-delete.html
@@ -8,7 +8,7 @@
       <h1 class="page-header__heading">Settings for <%= user.name %></h1>
       <% include alert.html %>
       <div class="tabbed">
-        <ul>
+        <nav>
           <li>
             <a href="/settings">Authorized Apps</a>
           </li>
@@ -21,7 +21,7 @@
           <li>
             <a href="/settings/delete" aria-selected="true">Delete Account</a>
           </li>
-        </ul>
+        </nav>
 
         <section id="section-delete"></section>
       </div>

--- a/templates/settings-password.html
+++ b/templates/settings-password.html
@@ -27,7 +27,7 @@
           <h2>Change Password</h2>
           <form action="/settings/password" method="POST" class="[ flow ]">
           <% if (totpPrompt) { %>
-            <div class="form-item [ flow ]">
+            <div class="form-field [ flow ]">
               <h2>Two-factor authentication</h2>
               <label for="x-hid-totp">Authentication code</label>
               <input

--- a/templates/settings-password.html
+++ b/templates/settings-password.html
@@ -18,9 +18,9 @@
 <!--          <li>-->
 <!--            <a href="#section-security">Security</a>-->
 <!--          </li>-->
-<!--          <li>-->
-<!--            <a href="#section-delete">Delete Account</a>-->
-<!--          </li>-->
+          <li>
+            <a href="/settings/delete">Delete Account</a>
+          </li>
         </ul>
 
         <section id="section-password">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -18,9 +18,9 @@
 <!--          <li>-->
 <!--            <a href="#section-security">Security</a>-->
 <!--          </li>-->
-<!--          <li>-->
-<!--            <a href="#section-delete">Delete Account</a>-->
-<!--          </li>-->
+          <li>
+            <a href="/settings/delete">Delete Account</a>
+          </li>
         </ul>
 
         <section id="section-apps">


### PR DESCRIPTION
# HID-2164

@orakili our TOTP logic for backup codes needed some love. For one, when setting up 2FA via API calls, it's possible to skip the `POST /totp/codes` API call and end up with half-configured 2FA that our `User.backupCodeIndex()` function was choking on. I added a quick guard to check each property in the nested objects to avoid such a heartbreak 💔 

Additionally, backup codes weren't getting removed — even when we logged that they were 🤦 — but that should be cleaned up now as well. To test the halfway 2FA state, run the following calls:

- `POST /jsonwebtoken` (to get your API key)
- `POST /totp/config` it will output a base64 image but also a plaintext config string that you can paste to an Auth app
- `POST /totp` — enable 2FA once your Auth app is generating codes
- Now you're at the halfway point. Try doing something that requires 2FA (login is fine) and when prompted for a token, enter  anything except 6 integers to trigger the backup code lookup. It would report that you have an `Invalid backup code !`

To test backup code deletion, first generate codes:

- `POST /totp/codes` — generate backup codes (see HID-2075 for lengthy thoughts on this API call)
- Take another action requiring 2FA. This time, use a backup code.
- Do one more action requiring 2FA. Use the **same backup code** and confirm that it prevents the action
- If you can think of another workflow and try to bust it, I'll be glad to have your feedback.

# HID-1970

@left23 non-admin users can delete their own account from settings. 2FA users require successful TOTP challenge.

- Test an admin user (ping me if you need assistance setting up an admin)
- Test a normal user without 2FA enabled (fresh registrations will be just fine)
- Test a normal user with 2FA enabled (again I'm here to help you set this up if the above instructions aren't enough)

Since you'll probably want to register a dummy account to repeatedly test this, I direct you toward the ReCAPTCHA which you can comment out:

https://github.com/UN-OCHA/hid_api/blob/bc7f93d7867e516bb7e2ab248615683b16fc9c1d/api/controllers/ViewController.js#L188

Like the other forms, I encourage you to try and trick the system any way you can: edit the DOM to change form validation, paste the form from a non-admin into the Admin's DOM, change primary email after loading form, you name it. I tried to be extremely thorough.