### PR TITLE
HID-2159: manage 2FA settings

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -415,7 +415,7 @@ module.exports = {
         return loginRedirect(request, reply);
       } catch (err) {
         const alert = {
-          type: 'danger',
+          type: 'error',
           message: err.output.payload.message,
         };
         return reply.view('totp', {
@@ -478,7 +478,7 @@ module.exports = {
         registerLink,
         passwordLink,
         alert: {
-          type: 'danger',
+          type: 'error',
           message: alertMessage,
         },
       });

--- a/api/controllers/TOTPController.js
+++ b/api/controllers/TOTPController.js
@@ -278,10 +278,17 @@ module.exports = {
    *   '401':
    *     description: Unauthorized.
    */
-  async disable(request) {
-    const user = request.auth.credentials;
+  async disable(request, internalArgs) {
+    let user;
+
+    if (internalArgs && internalArgs.user) {
+      user = internalArgs.user;
+    } else {
+      user = request.auth.credentials;
+    }
+
+    // TOTP is already disabled
     if (user.totp !== true) {
-      // TOTP is already disabled
       logger.warn(
         '[TOTPController->disable] 2FA already disabled.',
         {
@@ -292,9 +299,12 @@ module.exports = {
       );
       throw Boom.badRequest('2FA is already disabled.');
     }
+
+    // Disable user's 2FA.
     user.totp = false;
     user.totpConf = {};
     await user.save();
+
     logger.info(
       `[TOTPController->disable] Disabled 2FA for user ${user.id}`,
       {
@@ -305,6 +315,7 @@ module.exports = {
         },
       },
     );
+
     return user;
   },
 

--- a/api/controllers/TOTPController.js
+++ b/api/controllers/TOTPController.js
@@ -303,6 +303,7 @@ module.exports = {
     // Disable user's 2FA.
     user.totp = false;
     user.totpConf = {};
+    delete(user.totpMethod);
     await user.save();
 
     logger.info(

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -1083,18 +1083,11 @@ module.exports = {
       request.yar.set('session', cookie);
     }
 
-    // Status and Action are somewhat bound, so we put the state detection in
-    // unified variables to avoid terrible quirks.
-    //
-    // NOTE: The order of these might look strange, but it matches the state of
-    //       the user object in DB as the process progresses.
-    let complete = user.totpConf && user.totpConf.secret && user.totp && user.totpConf.backupCodes;
-
     // Status is a user-facing label
-    let status = complete ? 'enabled' : 'disabled';
+    let status = user.totp ? 'enabled' : 'disabled';
 
     // Action is a machine-facing value in the HTML forms.
-    let action = complete ? 'disable' : 'enable';
+    let action = user.totp ? 'disable' : 'enable';
 
     // Render settings-security page.
     return reply.view('settings-security', {

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -1066,11 +1066,20 @@ module.exports = {
       request.yar.set('session', cookie);
     }
 
+    // Check which step of 2FA process we're on
+    let step = 0;
+    if (cookie.step) {
+      step = cookie.step;
+      delete(cookie.step);
+      request.yar.set('session', cookie);
+    }
+
     // Render settings-security page.
     return reply.view('settings-security', {
       user,
       alert,
       totpPrompt,
+      step,
     });
   },
 

--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -45,6 +45,10 @@
 
   /* CD colours for components */
   --cd-blue-grey: #e6ecf1;
+  --cd-blue--bright: #80cbff;
+  --cd-grey--light: #f2f2f2;
+  --cd-grey--mid: #595959;
+  --cd-grey--dark: #4a4a4a;
 }
 
 /**

--- a/assets/css/settings-security.css
+++ b/assets/css/settings-security.css
@@ -24,3 +24,32 @@
 .security__status--enabled {
   color: var(--cd-green);
 }
+
+/**
+ * Step 1: Setting up 2FA via QR code or plaintext URL
+ */
+.step-1 {}
+
+.step-1__config {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-around;
+}
+
+.step-1__config > .step-1__qr {
+  flex: 0 0 228px;
+  height: 228px;
+}
+
+.step-1__config > .step-1__url {
+  flex: 0 0 256px;
+  height: 228px;
+}
+
+.step-1__url p {
+  padding: 1em;
+  color: #111;
+  background: #eee;
+  font-family: monospace;
+  line-break: anywhere;
+}

--- a/assets/css/settings-security.css
+++ b/assets/css/settings-security.css
@@ -1,0 +1,3 @@
+/**
+ * User settings: 2FA
+ */

--- a/assets/css/settings-security.css
+++ b/assets/css/settings-security.css
@@ -42,6 +42,12 @@
   height: 228px;
 }
 
+@media (-ms-high-contrast:none) {
+  .step-1__config > .step-1__url {
+    flex: 0 0 526px;
+  }
+}
+
 .step-1__url p {
   padding: 1em;
   color: #111;

--- a/assets/css/settings-security.css
+++ b/assets/css/settings-security.css
@@ -14,10 +14,6 @@
 }
 
 .security__status--disabled {
-  color: var(--cd-red);
-}
-
-.security__status--partial {
   color: var(--cd-orange);
 }
 
@@ -26,7 +22,7 @@
 }
 
 /**
- * Step 1: Setting up 2FA via QR code or plaintext URL
+ * ENABLE Step 1: Setting up 2FA via QR code or plaintext URL
  */
 .step-1 {}
 
@@ -52,4 +48,29 @@
   background: #eee;
   font-family: monospace;
   line-break: anywhere;
+}
+
+/**
+ * ENABLE Step 2: display backup codes
+ */
+.step-2 {}
+
+.step-2__backup-codes {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-around;
+
+  padding: 1em;
+  color: #111;
+  background: #eee;
+  max-width: 30ch;
+}
+
+.step-2__backup-codes > * {
+  flex: 1 0 10ch;
+  margin: 0 1ch;
+
+  list-style-type: none;
+  font-family: monospace;
+  white-space: nowrap;
 }

--- a/assets/css/settings-security.css
+++ b/assets/css/settings-security.css
@@ -1,5 +1,7 @@
 /**
  * User settings: 2FA
+ *
+ * Dependencies: cd-alert
  */
 .security {}
 
@@ -7,6 +9,18 @@
   font-size: 1.25em;
 }
 
-.security__status strong {
+.security__status {
   text-transform: capitalize;
+}
+
+.security__status--disabled {
+  color: var(--cd-red);
+}
+
+.security__status--partial {
+  color: var(--cd-orange);
+}
+
+.security__status--enabled {
+  color: var(--cd-green);
 }

--- a/assets/css/settings-security.css
+++ b/assets/css/settings-security.css
@@ -1,3 +1,12 @@
 /**
  * User settings: 2FA
  */
+.security {}
+
+.security__status {
+  font-size: 1.25em;
+}
+
+.security__status strong {
+  text-transform: capitalize;
+}

--- a/config/routes.js
+++ b/config/routes.js
@@ -223,6 +223,24 @@ module.exports = [
 
   {
     method: 'GET',
+    path: '/settings/security',
+    handler: ViewController.settingsSecurity,
+    options: {
+      auth: false,
+    },
+  },
+
+  {
+    method: 'POST',
+    path: '/settings/security',
+    handler: ViewController.settingsSecuritySubmit,
+    options: {
+      auth: false,
+    },
+  },
+
+  {
+    method: 'GET',
     path: '/docs/{param*}',
     handler: {
       directory: {

--- a/templates/alert.html
+++ b/templates/alert.html
@@ -1,5 +1,3 @@
-<style><% include ../assets/css/cd-alert.css %></style>
-
 <% if (typeof alert !== 'undefined' && alert.type && alert.message) { %>
   <div class="cd-alert cd-alert--<%= alert.type %> [ flow ]" role="alert">
     <div class="cd-alert__message">

--- a/templates/header.ejs
+++ b/templates/header.ejs
@@ -9,6 +9,7 @@
     <base href="/">
     <link rel="stylesheet" href="assets/css/_normalize.css">
     <link rel="stylesheet" href="assets/css/_cube.css">
+    <link rel="stylesheet" href="assets/css/cd-alert.css">
     <link rel="stylesheet" href="assets/css/cd-button.css">
     <link rel="stylesheet" href="assets/css/cd.css">
     <link rel="stylesheet" href="assets/css/page.css">

--- a/templates/settings-password.html
+++ b/templates/settings-password.html
@@ -15,9 +15,9 @@
           <li>
             <a href="/settings/password" aria-selected="true">Password</a>
           </li>
-<!--          <li>-->
-<!--            <a href="#section-security">Security</a>-->
-<!--          </li>-->
+          <li>
+            <a href="/settings/security">Security</a>
+          </li>
 <!--          <li>-->
 <!--            <a href="#section-delete">Delete Account</a>-->
 <!--          </li>-->

--- a/templates/settings-password.html
+++ b/templates/settings-password.html
@@ -26,84 +26,83 @@
         <section id="section-password">
           <h2>Change Password</h2>
           <form action="/settings/password" method="POST" class="[ flow ]">
-          <% if (totpPrompt) { %>
-            <div class="form-item [ flow ]">
-              <h3>Two-factor authentication</h3>
-              <label for="x-hid-totp">Authentication code</label>
-              <input
-                type="text"
-                name="x-hid-totp"
-                id="x-hid-totp"
-                autocomplete="one-time-code"
-                placeholder="Authentication code"
-                required>
-              <button name="action" value="totp" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
-                Verify
-              </button>
-            </div>
+            <% if (totpPrompt) { %>
+              <div class="form-item [ flow ]">
+                <h3>Two-factor authentication</h3>
+                <label for="x-hid-totp">Authentication code</label>
+                <input
+                  type="text"
+                  name="x-hid-totp"
+                  id="x-hid-totp"
+                  autocomplete="one-time-code"
+                  placeholder="Authentication code"
+                  required>
+                <button name="action" value="totp" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
+                  Verify
+                </button>
+              </div>
+            <% } else { %>
+              <div class="form-field">
+                <label for="password">Current password</label>
+                <input
+                  type="password"
+                  name="old_password"
+                  id="old_password"
+                  autocomplete="current-password"
+                  required
+                  minlength="12"
+                  pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
+                  title="See password requirements below.">
+              </div>
+
+              <div class="form-field">
+                <label for="password">New password</label>
+                <input
+                  type="password"
+                  name="new_password"
+                  id="password"
+                  autocomplete="new-password"
+                  required
+                  minlength="12"
+                  pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
+                  title="See password requirements below.">
+              </div>
+              <div class="form-field">
+                <label for="confirm_password">Confirm new password</label>
+                <input
+                  type="password"
+                  name="confirm_password"
+                  id="confirm_password"
+                  autocomplete="new-password"
+                  required
+                  minlength="12"
+                  pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
+                  title="See password requirements below.">
+              </div>
+              <div class="form-field">
+                <p>Passwords must be at least 12 characters long and:</p>
+                <ul>
+                  <li>Contain <strong>one number</strong></li>
+                  <li>Contain <strong>one uppercase character</strong></li>
+                  <li>Contain <strong>one lowercase character</strong></li>
+                  <li>Contain <strong>one special character</strong> <code>!@#$%^&*()+=\`{}</code></li>
+                  <li>Be different than your previous password</li>
+                </ul>
+              </div>
+
+              <!--
+                here we include a hidden input with the username, per Chrome's
+                recommendation for a11y and specifically PW managers in this case.
+              -->
+              <input type="hidden" name="username" value="<%= user.email %>">
+
+              <div class="form-actions">
+                <button name="action" value="submit" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
+                  Reset password
+                </button>
+              </div>
+            <% } %>
           </form>
-          <% } else { %>
-            <div class="form-field">
-              <label for="password">Current password</label>
-              <input
-                type="password"
-                name="old_password"
-                id="old_password"
-                autocomplete="current-password"
-                required
-                minlength="12"
-                pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
-                title="See password requirements below.">
-            </div>
-
-            <div class="form-field">
-              <label for="password">New password</label>
-              <input
-                type="password"
-                name="new_password"
-                id="password"
-                autocomplete="new-password"
-                required
-                minlength="12"
-                pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
-                title="See password requirements below.">
-            </div>
-            <div class="form-field">
-              <label for="confirm_password">Confirm new password</label>
-              <input
-                type="password"
-                name="confirm_password"
-                id="confirm_password"
-                autocomplete="new-password"
-                required
-                minlength="12"
-                pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
-                title="See password requirements below.">
-            </div>
-            <div class="form-field">
-              <p>Passwords must be at least 12 characters long and:</p>
-              <ul>
-                <li>Contain <strong>one number</strong></li>
-                <li>Contain <strong>one uppercase character</strong></li>
-                <li>Contain <strong>one lowercase character</strong></li>
-                <li>Contain <strong>one special character</strong> <code>!@#$%^&*()+=\`{}</code></li>
-                <li>Be different than your previous password</li>
-              </ul>
-            </div>
-
-            <!--
-              here we include a hidden input with the username, per Chrome's
-              recommendation for a11y and specifically PW managers in this case.
-            -->
-            <input type="hidden" name="username" value="<%= user.email %>">
-
-            <div class="form-actions">
-              <button name="action" value="submit" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
-                Reset password
-              </button>
-            </div>
-          </form>
-          <% } %>
         </section>
       </div>
     </div>

--- a/templates/settings-security.html
+++ b/templates/settings-security.html
@@ -43,7 +43,7 @@
             <% // The user is about to DISABLE their 2FA by submitting a code.
               if (step === 1) {
             %>
-              <%- include('totp-confirm.html') %>
+              <%- include('totp-confirm.html', { action: 'totp-disable' }) %>
             <% } %>
 
             <% // ENABLING 2FA was just completed, and we have backup codes to show.
@@ -118,7 +118,7 @@
                     <% } %>
                   </div>
 
-                  <%- include('totp-confirm.html') %>
+                  <%- include('totp-confirm.html', {action: 'totp-enable'}) %>
 
                 <% } else { %>
 

--- a/templates/settings-security.html
+++ b/templates/settings-security.html
@@ -22,36 +22,24 @@
 <!--          </li>-->
       </nav>
 
-      <%
-        let status = user.totp
-          ? user.totpConf && user.totpConf.secret && user.totpConf.backupCodes
-            ? 'enabled'
-            : 'partial'
-          : 'disabled';
-        let action = user.totp ? 'disable' : 'enable';
-      %>
-
       <section id="section-security" class="security">
         <h2>Manage Security</h2>
         <p class="security__status">Status: <strong class="security__status--<%= status %>"><%= status %></strong></p>
 
         <form action="/settings/security" method="POST" class="[ flow ]">
-          <% if (totpPrompt) { %>
-            <div class="form-item [ flow ]">
-              <h3>Two-factor authentication</h3>
-              <label for="x-hid-totp">Authentication code</label>
-              <input
-                type="text"
-                name="x-hid-totp"
-                id="x-hid-totp"
-                autocomplete="one-time-code"
-                placeholder="Authentication code"
-                required>
-              <button name="action" value="totp" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
-                Verify
-              </button>
-            </div>
-          <% } else { %>
+          <input type="hidden" name="step" value="<%= step %>">
+
+          <% if (status === 'enabled') { %>
+            <% if (step === 0) { %>
+              <p>Manage your <strong>two-factor authentication</strong> (2FA) settings here.</p>
+            <% } %>
+
+            <% if (step === 1) { %>
+              <%- include('totp-confirm.html') %>
+            <% } %>
+          <% } %>
+
+          <% if (status !== 'enabled') { %>
             <% if (step === 0) { %>
               <% if (user.totp) { %>
                 <p>Manage your <strong>two-factor authentication</strong> (2FA) settings here.</p>
@@ -67,9 +55,51 @@
             <% } %>
 
             <% if (step === 1) { %>
+              <div class="step-1">
+                <% if (formData && formData.totpConf) { %>
+                  <%-
+                    include('alert.html', {
+                      alert: {
+                        type: 'info',
+                        message: `
+                          <p>Use the QR code to set up the authenticator app of your choice (Google Authenticator, 1Password, Authy, etc)</p>
+                          <p>The plaintext configuration is available if you cannot scan the QR code.</p>
+                        `,
+                      },
+                    })
+                  %>
+
+                  <div class="step-1__config">
+                    <% if (formData.totpConf.qr) { %>
+                      <div class="step-1__qr">
+                        <img src="<%= formData.totpConf.qr %>" width="228" height="228">
+                      </div>
+                    <% } %>
+                    <% if (formData.totpConf.url) { %>
+                      <div class="step-1__url">
+                        <p><%= formData.totpConf.url %></p>
+                      </div>
+                    <% } %>
+                  </div>
+
+                  <%- include('totp-confirm.html') %>
+
+                <% } else { %>
+
+                  <%-
+                    include('alert.html', {
+                      alert: {
+                        type: 'warning',
+                        message: '<p>There was a problem displaying your two-factor authentication setup data. If this problem persists please email info@humanitarian.id and include this error code: SEC-1-QR.</p>',
+                      },
+                    });
+                  %>
+
+                <% } %>
+              </div>
             <% } %>
 
-            <% if (step === 0) { %>
+            <% if (step === 2) { %>
             <% } %>
           <% } %>
         </form>

--- a/templates/settings-security.html
+++ b/templates/settings-security.html
@@ -24,7 +24,7 @@
 
       <section id="section-security" class="security">
         <h2>Manage Security</h2>
-        <p class="security__status">Status: <strong class="security__status--<%= status %>"><%= status %></strong></p>
+        <p class="security__status">Extra security: <strong class="security__status--<%= status %>"><%= status %></strong></p>
 
         <form action="/settings/security" method="POST" class="[ flow ]">
           <input type="hidden" name="step" value="<%= step %>">
@@ -32,20 +32,56 @@
           <% if (status === 'enabled') { %>
             <% if (step === 0) { %>
               <p>Manage your <strong>two-factor authentication</strong> (2FA) settings here.</p>
+
+              <div class="form-actions">
+                <button name="action" value="<%= action %>" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase <%= status === 'enabled' ? 'cd-button--danger' : '' %>">
+                  <%= action %> 2FA
+                </button>
+              </div>
             <% } %>
 
-            <% if (step === 1) { %>
+            <% // The user is about to DISABLE their 2FA by submitting a code.
+              if (step === 1) {
+            %>
               <%- include('totp-confirm.html') %>
+            <% } %>
+
+            <% // ENABLING 2FA was just completed, and we have backup codes to show.
+              if (step === 2) {
+            %>
+              <div class="step-2">
+                <%-
+                  include('alert.html', {
+                    alert: {
+                      type: 'status',
+                      message: '<p>Your two-factor authentication is <strong>Enabled</strong>. However, keep reading for the final step.</p>',
+                    },
+                  })
+                %>
+                <%-
+                  include('alert.html', {
+                    alert: {
+                      type: 'warning',
+                      message: `
+                        <p><strong>Store these backup codes in a secure location!</strong> In the event you lose access to your authenticator app the backup codes can be used to log in, restore access to your account, and reconfigure 2FA with a new device.</p>
+                        <p>If you lose both your authenticator app and the backup codes, <strong>we CANNOT restore access to your account!</strong></p>
+                      `,
+                    },
+                  })
+                %>
+
+                <ul class="step-2__backup-codes">
+                  <li>HID 2FA Backup Codes</li>
+                  <li>------------------------</li>
+                  <li><%- formData.backupCodes.join('</li><li>') %></li>
+                </ul>
+              </div>
             <% } %>
           <% } %>
 
           <% if (status !== 'enabled') { %>
             <% if (step === 0) { %>
-              <% if (user.totp) { %>
-                <p>Manage your <strong>two-factor authentication</strong> (2FA) settings here.</p>
-              <% } else { %>
-                <p>To enhance the security of your account, you can enable <strong>two-factor authentication</strong> (2FA) to protect your HID account in case your password is compromised.</p>
-              <% } %>
+              <p>To enhance the security of your account, you can enable <strong>two-factor authentication</strong> (2FA) to protect your HID account in case your password is compromised.</p>
 
               <div class="form-actions">
                 <button name="action" value="<%= action %>" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase <%= status === 'enabled' ? 'cd-button--danger' : '' %>">
@@ -97,9 +133,6 @@
 
                 <% } %>
               </div>
-            <% } %>
-
-            <% if (step === 2) { %>
             <% } %>
           <% } %>
         </form>

--- a/templates/settings-security.html
+++ b/templates/settings-security.html
@@ -22,9 +22,21 @@
 <!--          </li>-->
       </nav>
 
-      <section id="section-security">
+      <%
+        let status = user.totp ? 'enabled' : 'disabled';
+        let action = user.totp ? 'disable' : 'enable';
+      %>
+
+      <section id="section-security" class="security">
         <h2>Manage Security</h2>
-        <p>To enhance the security of your account, you can enable <strong>two-factor authentication</strong> (2FA) to protect your HID account in case your password is compromised.</p>
+        <p class="security__status security__status--<%= status %>">Status: <strong><%= status %></strong></p>
+
+        <% if (user.totp) { %>
+          <p>Manage your <strong>two-factor authentication</strong> (2FA) settings here.</p>
+        <% } else { %>
+          <p>To enhance the security of your account, you can enable <strong>two-factor authentication</strong> (2FA) to protect your HID account in case your password is compromised.</p>
+        <% } %>
+
         <form action="/settings/security" method="POST" class="[ flow ]">
           <% if (totpPrompt) { %>
             <div class="form-item [ flow ]">
@@ -42,9 +54,6 @@
               </button>
             </div>
           <% } else { %>
-            <%
-              let action = user.totp ? 'disable' : 'enable';
-            %>
             <div class="form-actions">
               <button name="action" value="<%= action %>" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
                 <%= action %> 2FA

--- a/templates/settings-security.html
+++ b/templates/settings-security.html
@@ -23,19 +23,17 @@
       </nav>
 
       <%
-        let status = user.totp ? 'enabled' : 'disabled';
+        let status = user.totp
+          ? user.totpConf && user.totpConf.secret && user.totpConf.backupCodes
+            ? 'enabled'
+            : 'partial'
+          : 'disabled';
         let action = user.totp ? 'disable' : 'enable';
       %>
 
       <section id="section-security" class="security">
         <h2>Manage Security</h2>
-        <p class="security__status security__status--<%= status %>">Status: <strong><%= status %></strong></p>
-
-        <% if (user.totp) { %>
-          <p>Manage your <strong>two-factor authentication</strong> (2FA) settings here.</p>
-        <% } else { %>
-          <p>To enhance the security of your account, you can enable <strong>two-factor authentication</strong> (2FA) to protect your HID account in case your password is compromised.</p>
-        <% } %>
+        <p class="security__status">Status: <strong class="security__status--<%= status %>"><%= status %></strong></p>
 
         <form action="/settings/security" method="POST" class="[ flow ]">
           <% if (totpPrompt) { %>
@@ -54,11 +52,25 @@
               </button>
             </div>
           <% } else { %>
-            <div class="form-actions">
-              <button name="action" value="<%= action %>" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
-                <%= action %> 2FA
-              </button>
-            </div>
+            <% if (step === 0) { %>
+              <% if (user.totp) { %>
+                <p>Manage your <strong>two-factor authentication</strong> (2FA) settings here.</p>
+              <% } else { %>
+                <p>To enhance the security of your account, you can enable <strong>two-factor authentication</strong> (2FA) to protect your HID account in case your password is compromised.</p>
+              <% } %>
+
+              <div class="form-actions">
+                <button name="action" value="<%= action %>" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase <%= status === 'enabled' ? 'cd-button--danger' : '' %>">
+                  <%= action %> 2FA
+                </button>
+              </div>
+            <% } %>
+
+            <% if (step === 1) { %>
+            <% } %>
+
+            <% if (step === 0) { %>
+            <% } %>
           <% } %>
         </form>
       </section>

--- a/templates/settings-security.html
+++ b/templates/settings-security.html
@@ -71,8 +71,6 @@
                 %>
 
                 <ul class="step-2__backup-codes">
-                  <li>HID 2FA Backup Codes</li>
-                  <li>------------------------</li>
                   <li><%- formData.backupCodes.join('</li><li>') %></li>
                 </ul>
               </div>

--- a/templates/settings-security.html
+++ b/templates/settings-security.html
@@ -1,0 +1,63 @@
+<% include header %>
+<style><% include ../assets/css/tabs.css %></style>
+<style><% include ../assets/css/settings-security.css %></style>
+
+<main role="main" id="main-content" class="cd-container">
+  <div class="cd-layout-content">
+    <h1 class="page-header__heading">Settings for <%= user.name %></h1>
+    <% include alert.html %>
+    <div class="tabbed">
+      <nav>
+        <li>
+          <a href="/settings">Authorized Apps</a>
+        </li>
+        <li>
+          <a href="/settings/password">Password</a>
+        </li>
+        <li>
+          <a href="/settings/security" aria-selected="true">Security</a>
+        </li>
+<!--          <li>-->
+<!--            <a href="#section-delete">Delete Account</a>-->
+<!--          </li>-->
+      </nav>
+
+      <section id="section-security">
+        <h2>Manage Security</h2>
+        <p>To enhance the security of your account, you can enable <strong>two-factor authentication</strong> (2FA) to protect your HID account in case your password is compromised.</p>
+        <form action="/settings/security" method="POST" class="[ flow ]">
+          <% if (totpPrompt) { %>
+            <div class="form-item [ flow ]">
+              <h3>Two-factor authentication</h3>
+              <label for="x-hid-totp">Authentication code</label>
+              <input
+                type="text"
+                name="x-hid-totp"
+                id="x-hid-totp"
+                autocomplete="one-time-code"
+                placeholder="Authentication code"
+                required>
+              <button name="action" value="totp" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
+                Verify
+              </button>
+            </div>
+          <% } else { %>
+            <%
+              let action = user.totp ? 'disable' : 'enable';
+            %>
+            <div class="form-actions">
+              <button name="action" value="<%= action %>" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
+                <%= action %> 2FA
+              </button>
+            </div>
+          <% } %>
+        </form>
+      </section>
+    </div>
+  </div>
+</main>
+
+<% include footer %>
+
+<script><% include ../assets/js/tabs.js %></script>
+<script><% include ../assets/js/totp.js %></script>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -15,9 +15,9 @@
           <li>
             <a href="/settings/password">Password</a>
           </li>
-<!--          <li>-->
-<!--            <a href="#section-security">Security</a>-->
-<!--          </li>-->
+          <li>
+            <a href="/settings/security">Security</a>
+          </li>
 <!--          <li>-->
 <!--            <a href="#section-delete">Delete Account</a>-->
 <!--          </li>-->

--- a/templates/totp-confirm.html
+++ b/templates/totp-confirm.html
@@ -1,0 +1,14 @@
+<div class="form-item [ flow ]">
+  <h3>Two-factor authentication</h3>
+  <label for="x-hid-totp">Authentication code</label>
+  <input
+    type="text"
+    name="x-hid-totp"
+    id="x-hid-totp"
+    autocomplete="one-time-code"
+    placeholder="Authentication code"
+    required>
+  <button name="action" value="totp" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
+    Verify
+  </button>
+</div>

--- a/templates/totp-confirm.html
+++ b/templates/totp-confirm.html
@@ -8,7 +8,7 @@
     autocomplete="one-time-code"
     placeholder="Authentication code"
     required>
-  <button name="action" value="totp" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
+  <button name="action" value="<%= typeof action !== 'undefined' ? action : 'totp' %>" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">
     Verify
   </button>
 </div>


### PR DESCRIPTION
# HID-2159

HID Auth users now have 2FA settings available. You should be able to:

- Enable 2FA and it shows up during login, for instance.
- Go back to settings and disable 2FA by again entering a token or backup code.

I updated the following methods but tested them pretty thoroughly and the changes were very small anyway:

- `TOTPController.generateConfig()`
- `TOTPController.generateBackupCodes()`
- `TOTPController.enable()`
- `TOTPController.disable()`