### PR TITLE
HID-2142: log when listing OAuth client(s)

### DIFF
--- a/api/controllers/ClientController.js
+++ b/api/controllers/ClientController.js
@@ -165,6 +165,8 @@ module.exports = {
     const sort = request.query.sort || 'name';
     options.sort = sort;
     const results = await HelperService.find(Client, criteria, options);
+
+    // Count results and totals for pagination+logging
     const count = results.length;
     const total = await Client.countDocuments(criteria);
 

--- a/api/controllers/ClientController.js
+++ b/api/controllers/ClientController.js
@@ -86,7 +86,7 @@ module.exports = {
    *     in: query
    *     type: integer
    *     required: false
-   *     default: 50
+   *     default: 100
    * responses:
    *   '200':
    *     description: Array of client objects.
@@ -162,6 +162,8 @@ module.exports = {
     }
 
     // Otherwise do a larger query for multiple records.
+    const sort = request.query.sort || 'name';
+    options.sort = sort;
     const results = await HelperService.find(Client, criteria, options);
     const count = results.length;
     const total = await Client.countDocuments(criteria);

--- a/docs/hid.yml
+++ b/docs/hid.yml
@@ -258,7 +258,7 @@ paths:
           in: query
           type: integer
           required: false
-          default: 50
+          default: 100
       responses:
         '200':
           description: Array of client objects.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-2142

Added logging to `ClientController.find()` and also corrected a few discrepancies with docs:

- the default `sort` was actually `_id` but we advertise `name` — it should really be `name` now 
- the default pagination was 50 but it's 100. Docs updated to say 100.
- the logs now list how many records were displayed, and who asked to see them in ELK meta fields
- the pre-existing 404 log also contains the security-related meta fields

Endpoints to test (you must have an HID user who has `user.is_admin=true`:
- `GET /api/v3/client`
- `GET /api/v3/client/{id}`
