### PR TITLE
HID-2117: fix ugly errors during Authorization process

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -554,9 +554,9 @@ module.exports = {
       const clientId = request.query.client_id;
       user.sanitize(user);
       request.auth.credentials = user;
-      const result = await oauth.authorize(request, reply, {}, async (clientID, redirect, done) => {
+      const result = await oauth.authorize(request, reply, {}, async (oauthClientId, redirect, done) => {
         try {
-          const client = await Client.findOne({ id: clientID });
+          const client = await Client.findOne({ id: oauthClientId });
           if (!client || !client.id) {
             logger.warn(
               '[AuthController->authorizeDialogOauth2] Unsuccessful OAuth2 authorization because client was not found',
@@ -568,7 +568,7 @@ module.exports = {
                   id: cookie.userId,
                 },
                 oauth: {
-                  client_id: clientID,
+                  client_id: oauthClientId,
                 },
               },
             );

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -554,7 +554,8 @@ module.exports = {
       const clientId = request.query.client_id;
       user.sanitize(user);
       request.auth.credentials = user;
-      const result = await oauth.authorize(request, reply, {}, async (oauthClientId, redirect, done) => {
+      const options = {};
+      const result = await oauth.authorize(request, reply, options, async (oauthClientId, redirect, done) => {
         try {
           const client = await Client.findOne({ id: oauthClientId });
           if (!client || !client.id) {

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -550,13 +550,18 @@ module.exports = {
 
       // If the user is authenticated, then check whether the user has confirmed
       // authorization for this client/scope combination.
+      const options = {};
       const user = await User.findOne({ _id: cookie.userId }).populate({ path: 'authorizedClients', select: 'id name' });
       const clientId = request.query.client_id;
       user.sanitize(user);
       request.auth.credentials = user;
-      const options = {};
-      const result = await oauth.authorize(request, reply, options, async (oauthClientId, redirect, done) => {
+
+      // Validate the OAuth Authorization request. If any parameters are missing
+      // or invalid, it will throw an error internally, but will show a generic
+      // message about configuration to the user.
+      const [req, res] = await oauth.authorize(request, reply, options, async (oauthClientId, redirect, done) => {
         try {
+          // Verify OAuth Client ID.
           const client = await Client.findOne({ id: oauthClientId });
           if (!client || !client.id) {
             logger.warn(
@@ -573,11 +578,11 @@ module.exports = {
                 },
               },
             );
-            return done(
-              'An error occurred while processing the request. Please try logging in again.',
-            );
+
+            throw Error(`Client ID does not exist: ${oauthClientId}`);
           }
-          // Verify redirect uri
+
+          // Verify redirect_uri
           if (client.redirectUri !== redirect && !client.redirectUrls.includes(redirect)) {
             logger.warn(
               '[AuthController->authorizeDialogOauth2] Unsuccessful OAuth2 authorization due to wrong redirect URI',
@@ -594,33 +599,53 @@ module.exports = {
                 },
               },
             );
-            return done('Wrong redirect URI');
+            throw Error(`Wrong redirect URI: ${redirect}`);
           }
+          // The request passed validation. Proceed.
           return done(null, client, redirect);
         } catch (err) {
-          logger.error(
-            `[AuthController->authorizeDialogOauth2] ${err.message}`,
-            {
-              request,
-              security: true,
-              fail: true,
-              user: {
-                id: cookie.userId,
+          // Check the error object and potentially log the error if it does NOT
+          // contain one of the validation problems we already logged. We log
+          // validation problems before throwing in order to provide contextual
+          // metadata in the logs, so that known problems can be more easily
+          // found in Kibana.
+          //
+          // If we didn't find any known problems, we should log the error. This
+          // conditional needs to have one test for each Error() in the preceding
+          // try() block.
+          if (
+            err.message
+            && err.message.indexOf('Client ID does not exist') === -1
+            && err.message.indexOf('Wrong redirect URI') === -1
+          ) {
+            logger.error(
+              `[AuthController->authorizeDialogOauth2] ${err.message}`,
+              {
+                request,
+                security: true,
+                fail: true,
+                user: {
+                  id: cookie.userId,
+                },
+                stack_trace: err.stack,
               },
-              stack_trace: err.stack,
-            },
-          );
-          return done('An error occurred while processing the request. Please try logging in again.');
+            );
+          }
+
+          // Finish the OAuth validation process.
+          return done('catch()');
         }
       });
-      const req = result[0];
+
+      // If we made it this far, the OAuth config seems legit. Check user data
+      // to see if they already have this client in their approved list.
       if (user.authorizedClients && user.hasAuthorizedClient(clientId)) {
         request.payload = { transaction_id: req.oauth2.transactionID };
         const response = await oauth.decision(request, reply);
         return response;
       }
-      // The user has not confirmed authorization, so present the
-      // authorization page if prompt != none.
+
+      // If prompt === none, redirect immediately.
       if (prompt === 'none') {
         return reply.redirect(
           `${request.query.redirect_uri
@@ -629,6 +654,9 @@ module.exports = {
           }&nonce=${request.query.nonce
           }`);
       }
+
+      // The user has not confirmed authorization, so display the authorization
+      // dialog to the user and let them decide to approve/deny.
       return reply.view('authorize', {
         user,
         client: req.oauth2.client,
@@ -636,16 +664,21 @@ module.exports = {
         // csrf: req.csrfToken()
       });
     } catch (err) {
-      logger.error(
-        `[AuthController->authorizeDialogOauth2] ${err.message}`,
-        {
-          request,
-          security: true,
-          fail: true,
-          stack_trace: err.stack,
+      // Display a human-friendly error.
+      //
+      // We're not doing additional logging in this block because we logged the
+      // errors as they were caught in the code above.
+      return reply.view('message', {
+        title: 'Configuration problem on original website',
+        alert: {
+          type: 'error',
+          message: `
+            <p>The website which sent you to HID appears to have invalid configuration.</p>
+            <p>We have logged the problem internally.</p>
+          `,
         },
-      );
-      return err;
+        isSuccess: false,
+      });
     }
   },
 

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -504,9 +504,12 @@ module.exports = {
           },
         );
 
-        return reply.redirect(`${request.query.redirect_uri}?error=invalid_request&state=${request.query.state
-        }&scope=${request.query.scope
-        }&nonce=${request.query.nonce}`);
+        return reply.redirect(
+          `${request.query.redirect_uri
+          }?error=invalid_request&state=${request.query.state
+          }&scope=${request.query.scope
+          }&nonce=${request.query.nonce
+          }`);
       }
 
       // If the user is not authenticated, redirect to the login page and preserve
@@ -515,9 +518,12 @@ module.exports = {
       if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp) || prompt === 'login') {
         // If user is not logged in and prompt is set to none, throw an error message.
         if (prompt === 'none') {
-          return reply.redirect(`${request.query.redirect_uri}?error=login_required&state=${request.query.state
-          }&scope=${request.query.scope
-          }&nonce=${request.query.nonce}`);
+          return reply.redirect(
+            `${request.query.redirect_uri
+            }?error=login_required&state=${request.query.state
+            }&scope=${request.query.scope
+            }&nonce=${request.query.nonce
+            }`);
         }
         logger.info(
           '[AuthController->authorizeDialogOauth2] Get request to /oauth/authorize without session. Redirecting to the login page.',
@@ -537,7 +543,8 @@ module.exports = {
           }&response_type=${request.query.response_type
           }&state=${request.query.state
           }&scope=${request.query.scope
-          }&nonce=${request.query.nonce}#login`,
+          }&nonce=${request.query.nonce
+          }#login`,
         );
       }
 
@@ -614,9 +621,12 @@ module.exports = {
       // The user has not confirmed authorization, so present the
       // authorization page if prompt != none.
       if (prompt === 'none') {
-        return reply.redirect(`${request.query.redirect_uri}?error=interaction_required&state=${request.query.state
-        }&scope=${request.query.scope
-        }&nonce=${request.query.nonce}`);
+        return reply.redirect(
+          `${request.query.redirect_uri
+          }?error=interaction_required&state=${request.query.state
+          }&scope=${request.query.scope
+          }&nonce=${request.query.nonce
+          }`);
       }
       return reply.view('authorize', {
         user,
@@ -655,12 +665,14 @@ module.exports = {
             },
           },
         );
-        return reply.redirect(`/?redirect=/oauth/authorize&client_id=${request.query.client_id
-        }&redirect_uri=${request.query.redirect_uri
-        }&response_type=${request.query.response_type
-        }&state=${request.query.state
-        }&scope=${request.query.scope
-        }&nonce=${request.query.nonce}#login`);
+        return reply.redirect(
+          `/?redirect=/oauth/authorize&client_id=${request.query.client_id
+          }&redirect_uri=${request.query.redirect_uri
+          }&response_type=${request.query.response_type
+          }&state=${request.query.state
+          }&scope=${request.query.scope
+          }&nonce=${request.query.nonce
+          }#login`);
       }
 
       const user = await User.findOne({ _id: cookie.userId });

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -95,30 +95,8 @@ module.exports = {
       alert: false,
     };
 
-    // Check client ID and redirect URI at this stage, so we can send an error message if needed.
-    if (request.query.client_id) {
-      try {
-        const client = await Client.findOne({ id: request.query.client_id });
-        if (!client
-          || (client && client.redirectUri !== request.query.redirect_uri
-            && !client.redirectUrls.includes(request.query.redirect_uri))) {
-          loginArgs.alert = {
-            type: 'error',
-            message: 'The configuration of the client application is invalid. We can not log you in.',
-          };
-          return reply.view('login', loginArgs);
-        }
-        return reply.view('login', loginArgs);
-      } catch (err) {
-        loginArgs.alert = {
-          type: 'error',
-          message: 'Internal server error. We can not log you in. Please let us know at info@humanitarian.id',
-        };
-        return reply.view('login', loginArgs);
-      }
-    } else {
-      return reply.view('login', loginArgs);
-    }
+    // Display login page.
+    return reply.view('login', loginArgs);
   },
 
   async logout(request, reply) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.1",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.1",
+  "version": "3.0.3",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,12 +1,12 @@
 <% include header %>
-<div class="api-page">
-  <main role="main" id="main-content" class="cd-container">
-    <div class="cd-layout-content">
-      <div class="[ flow ]">
-        <h1 class="page-header__heading">Error</h1>
-        <p>Sorry, there was an error.</p>
-      </div>
+
+<main role="main" id="main-content" class="cd-container">
+  <div class="cd-layout-content">
+    <div class="[ flow ]">
+      <h1 class="page-header__heading">Error</h1>
+      <p>Sorry, there was an internal server error.</p>
     </div>
-  </main>
-</div>
+  </div>
+</main>
+
 <% include footer %>

--- a/templates/message.html
+++ b/templates/message.html
@@ -1,15 +1,15 @@
 <% include header %>
-<div class="api-page">
-  <main role="main" id="main-content" class="cd-container">
-    <div class="cd-layout-content">
-      <div class="[ flow ]">
-        <h1 class="page-header__heading"><%= title %></h1>
-        <% include alert.html %>
-        <% if (isSuccess) { %>
-          <p class="form-field">Now you can login on <a href="https://auth.humanitarian.id">Humanitarian ID</a> or one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service" target="_blank">partner websites</a>.</p>
-        <% } %>
-      </div>
+
+<main role="main" id="main-content" class="cd-container">
+  <div class="cd-layout-content">
+    <div class="[ flow ]">
+      <h1 class="page-header__heading"><%= title %></h1>
+      <% include alert.html %>
+      <% if (isSuccess) { %>
+        <p>Now you can login on <a href="https://auth.humanitarian.id">Humanitarian ID</a> or one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service" target="_blank">partner websites</a>.</p>
+      <% } %>
     </div>
-  </main>
-</div>
+  </div>
+</main>
+
 <% include footer %>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -29,7 +29,7 @@
             <% if (user.authorizedClients.length === 0) { %>
               <p><em>You haven't authorized any websites yet. After you log in with HID on one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service.html" target="_blank" rel="noopener">Partner Sites</a> you will see it listed here.</em></p>
             <% } else { %>
-              <p>You have <strong><%= user.authorizedClients.length %> websites</strong> that have been granted access to your profile.</p>
+              <p>You have granted <strong><%= user.authorizedClients.length %> website<%= user.authorizedClients.length === 1 ? '' : 's' %></strong> access to your profile.</p>
               <ul class="oauth-clients-list [ flow ]">
               <%
                 const sorted = user.authorizedClients.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
# HID-2117

Sometimes HID outputs ugly errors that make it look unstable. It turned out the errors were being displayed that way on purpose (more or less). So this PR fixes the branding issues and makes the error much more user-friendly.

## Testing

Unfortunately to test this you have to craft an OAuth request. I have a puppeteer script sitting around which lets me skip manually logging in and it autofills forms and stuff. I can put it in a repo if you want, but you can also trigger the Authorization by using the following URL template:

```
GET http://api.hid.vm/oauth/authorize
  ?response_type=token
  &client_id=chris-debug
  &client_secret=0123456789abcdefghijklmnopqrstuvwxyz
  &redirect_uri=http%3A%2F%2Fchris.debug.test%2Flogin%2Fcallback
  &state=12345
  &nonce=19207
```

You will have to create that client, or replace the dummy data shown here with a client from your DB. Generally I recommend against using Prod config because if all goes well, you end up at a prod URL which collects analytics.

 The three conditions affecting the PR are:
- FAIL `client_id` — send something that does NOT exist in the DB to trigger the error
- FAIL `redirect_uri` — send something that does NOT exist in the DB (either `redirect_uri` or in the array of `redirect_urls`)
- PASS: when you craft a valid URL, does it still work?
