### PR TITLE
HID-2136: prevent 500 during access_token requests

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -865,7 +865,7 @@ module.exports = {
             fail: true,
           },
         );
-        throw Boom.badRequest('Missing authorization code');
+        return Boom.unauthorized('Missing authorization code');
       }
 
       // Check client_id and client_secret
@@ -899,7 +899,7 @@ module.exports = {
             fail: true,
           },
         );
-        throw Boom.badRequest('invalid client authentication');
+        return Boom.unauthorized('invalid client authentication');
       }
 
       // Look up OAuth Client in DB.
@@ -916,7 +916,7 @@ module.exports = {
             },
           },
         );
-        throw Boom.badRequest('invalid client_id');
+        return Boom.badRequest('invalid client_id');
       }
 
       // Does the client_secret we received match the DB entry?
@@ -933,7 +933,7 @@ module.exports = {
             },
           },
         );
-        throw Boom.badRequest('invalid client_secret');
+        return Boom.unauthorized('invalid client_secret');
       }
 
       // Grab token and type.
@@ -955,10 +955,11 @@ module.exports = {
             },
           },
         );
+
         // OAuth2 standard error.
         const error = Boom.badRequest('invalid authorization code');
         error.output.payload.error = 'invalid_grant';
-        throw error;
+        return error;
       } else {
         logger.info(
           '[AuthController->accessTokenOauth2] Successful access token request',
@@ -985,7 +986,9 @@ module.exports = {
           stack_trace: err.stack,
         },
       );
-      return err;
+
+      // Send a documented error code back.
+      return Boom.badRequest(err.message);
     }
   },
 

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -813,8 +813,10 @@ module.exports = {
         // @see HID-2156
         user.authorizedClients.push(request.yar.authorize[request.payload.transaction_id].client);
         user.markModified('authorizedClients');
+        await user.save();
+
         logger.info(
-          '[AuthController->authorizeOauth2] Added authorizedClient to user',
+          '[AuthController->authorizeOauth2] Added OAuth Client to user profile',
           {
             request,
             security: true,
@@ -827,7 +829,6 @@ module.exports = {
             },
           },
         );
-        await user.save();
       }
       const response = await oauth.decision(request, reply);
       return response;

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -906,7 +906,7 @@ module.exports = {
       client = await Client.findOne({ id: clientId });
       if (!client) {
         logger.warn(
-          '[AuthController->accessTokenOAuth2] Unsuccessful access token request due to wrong client ID.',
+          '[AuthController->accessTokenOAuth2] Unsuccessful access token request due to non-existent client ID.',
           {
             request,
             security: true,
@@ -950,6 +950,7 @@ module.exports = {
             security: true,
             fail: true,
             oauth: {
+              client_id: clientId,
               code,
             },
           },

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -847,7 +847,7 @@ module.exports = {
   },
 
   /**
-   * Issues access tokens during "Extra Secure" OAuth flows.
+   * Issues an access_token during "Extra Secure" OAuth flows.
    *
    * @see https://github.com/UN-OCHA/hid_api/wiki/Integrating-with-HID-via-OAuth#step-2--request-access-and-id-tokens
    */
@@ -873,14 +873,12 @@ module.exports = {
       let clientId = null;
       let clientSecret = null;
 
-      // How is the authorization configured?
+      // Are we using POST body authorization?
       if (request.payload.client_id && request.payload.client_secret) {
-        // Using client_secret_post authorization
         clientId = request.payload.client_id;
         clientSecret = request.payload.client_secret;
       }
-      // Using client_secret_basic authorization.
-      // Decrypt the Authorization header.
+      // Are we using Basic Auth?
       else if (request.headers.authorization) {
         const parts = request.headers.authorization.split(' ');
         if (parts.length === 2) {
@@ -890,7 +888,9 @@ module.exports = {
           const cparts = text.split(':');
           [clientId, clientSecret] = cparts;
         }
-      } else {
+      }
+      // Neither authorization method found. Log it.
+      else {
         logger.warn(
           '[AuthController->accessTokenOAuth2] Unsuccessful access token request due to invalid client authentication.',
           {

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -966,8 +966,8 @@ module.exports = {
             request,
             security: true,
             oauth: {
-              client_id: request.payload.client_id,
-              client_secret: `${request.payload.client_secret.slice(0, 3)}...${request.payload.client_secret.slice(-3)}`,
+              client_id: clientId,
+              client_secret: `${clientSecret.slice(0, 3)}...${clientSecret.slice(-3)}`,
             },
           },
         );

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -529,6 +529,12 @@ module.exports = {
    * @see authorizeOauth2()
    */
   async authorizeDialogOauth2(request, reply) {
+    // For some errors, we end up showing a prompt saying that the problem
+    // originated on the website which sent the user to HID. It's not always
+    // possible, but when we can we populate this URL so we can link them back
+    // to where they came from.
+    let errorRedirectUrl = '';
+
     try {
       const oauth = request.server.plugins['hapi-oauth2orize'];
       const prompt = request.query.prompt ? request.query.prompt : '';
@@ -642,6 +648,10 @@ module.exports = {
                 },
               },
             );
+
+            // extract hostname from redirect URL
+            errorRedirectUrl = new URL(redirect).origin;
+
             throw Error(`Wrong redirect URI: ${redirect}`);
           }
 
@@ -719,6 +729,7 @@ module.exports = {
           message: `
             <p>The website which sent you to HID appears to have invalid configuration.</p>
             <p>We have logged the problem internally.</p>
+            ${ errorRedirectUrl ? '<br><p>Go back to <a href="'+ errorRedirectUrl +'">'+ errorRedirectUrl +'</a></p>' : '' }
           `,
         },
         isSuccess: false,

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -951,7 +951,8 @@ module.exports = {
             fail: true,
             oauth: {
               client_id: clientId,
-              code,
+              token: `${token.slice(0, 3)}...${token.slice(-3)}`,
+              type,
             },
           },
         );

--- a/api/controllers/OutlookController.js
+++ b/api/controllers/OutlookController.js
@@ -8,7 +8,6 @@ const User = require('../models/User');
 
 /**
  * @module OutlookController
- * @description Generated Trails.js Controller.
  */
 module.exports = {
 

--- a/api/controllers/WebhooksController.js
+++ b/api/controllers/WebhooksController.js
@@ -10,7 +10,6 @@ const { logger } = config;
 
 /**
  * @module WebhooksController
- * @description Generated Trails.js Controller.
  */
 
 // Notify users of a new disaster

--- a/config/main.js
+++ b/config/main.js
@@ -1,24 +1,10 @@
 /**
- * Trailpack Configuration
- * (app.config.main)
- *
- * @see http://trailsjs.io/doc/config/main
+ * Main Configuration
  */
-
-
 const path = require('path');
 
 module.exports = {
-
-  /**
-   * Order does *not* matter. Each module is loaded according to its own
-   * requirements.
-   */
-  packs: [
-    // require('trailpack-repl'),
-    // require('trailpack-router'),
-    // require('trailpack-hapi')
-  ],
+  packs: [],
 
   /**
    * Define application paths here. "root" is the only required path.

--- a/config/routes.js
+++ b/config/routes.js
@@ -1,10 +1,11 @@
 /**
- * Routes optionsuration
- * (trails.options.routes)
+ * Routes for HID Auth + API
  *
- * optionsure how routes map to views and controllers.
+ * - Anything prefixed with "/api" is the API
+ * - Everything else is HID Auth, which is a mix of OAuth-specific routes, plus
+ *   user-facing things like login forms, password resets, profile, and so forth
  *
- * @see http://trailsjs.io/doc/options/routes.js
+ * @see https://hapi.dev/tutorials/routing/
  */
 const Joi = require('@hapi/joi');
 

--- a/config/session.js
+++ b/config/session.js
@@ -1,13 +1,7 @@
 /**
  * Session Configuration
- * (app.config.session)
- *
- * @see http://trailsjs.io/doc/config/session.js
  */
-
-
 module.exports = {
-
   /**
    * Define the session implementation, e.g. 'jwt' or 'cookie'
    */
@@ -28,5 +22,4 @@ module.exports = {
   cookie: {
     maxAge: 24 * 60 * 60 * 1000,
   },
-
 };

--- a/config/web.js
+++ b/config/web.js
@@ -1,11 +1,6 @@
 /**
-* Server Configuration
-* (app.config.web)
-*
-* Configure the Web Server
-*
-* @see {@link http://trailsjs.io/doc/config/web}
-*/
+ * Server Configuration
+ */
 const inert = require('@hapi/inert');
 const ejs = require('ejs');
 const vision = require('@hapi/vision');
@@ -20,7 +15,6 @@ const OauthToken = require('../api/models/OauthToken');
 const JwtService = require('../api/services/JwtService');
 
 module.exports = {
-
   /**
   * The port to bind the web server to
   */
@@ -49,7 +43,7 @@ module.exports = {
       plugin: yar,
       options: {
         cache: {
-          expiresIn: 4 * 60 * 60 * 1000, // 4 hours sessions
+          expiresIn: 4 * 60 * 60 * 1000, // 4-hour sessions
         },
         cookieOptions: {
           password: process.env.COOKIE_PASSWORD,

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 3.0.0
+  version: 3.0.5
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.3",
+  "version": "3.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.3",
+  "version": "3.0.5",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",

--- a/plugins/hapi-oauth2orize/index.js
+++ b/plugins/hapi-oauth2orize/index.js
@@ -1,3 +1,11 @@
+/**
+ * hapi-oauth2orize
+ *
+ * Plugin to bridge between hapi (our server framework) and oauth2orize, which
+ * is intended to run as Express middleware.
+ *
+ * It seems to be inspired by https://github.com/oneblink/hapi-oauth2orize
+ */
 const Oauth2orize = require('oauth2orize');
 const Boom = require('@hapi/boom');
 const Hoek = require('@hapi/hoek');
@@ -8,17 +16,23 @@ const internals = {
   defaults: {
     credentialsUserProperty: 'user',
   },
+
   OauthServer: null,
+
   settings: null,
+
   grant(type, phase, fn) {
     internals.OauthServer.grant(type, phase, fn);
   },
+
   exchange(type, exchange) {
     internals.OauthServer.exchange(type, exchange);
   },
+
   errorHandler(options) {
     return internals.OauthServer.errorHandler(options);
   },
+
   async authorize(request, reply, options, validate, immediate) {
     const express = internals.convertToExpress(request, reply);
     const authorizeAsync = util.promisify(
@@ -28,6 +42,7 @@ const internals = {
     await authorizeAsync(express.req, express.res);
     return [express.req, express.res];
   },
+
   async decision(request, reply, aoptions, parse) {
     const express = internals.convertToExpress(request, reply);
 
@@ -44,17 +59,21 @@ const internals = {
     const response = await middlewareAsync(express.req, express.res);
     return response;
   },
+
   serializeClient(fn) {
     internals.OauthServer.serializeClient(fn);
   },
+
   deserializeClient(fn) {
     internals.OauthServer.deserializeClient(fn);
   },
+
   token(request, reply, options) {
     const express = internals.convertToExpress(request, reply);
     const tokenAsync = util.promisify(internals.OauthServer.token(options));
     return tokenAsync(express.req, express.res);
   },
+
   transformBoomError(aboomE, authE) {
     const boomE = aboomE;
     if (!boomE.isBoom) {
@@ -82,6 +101,7 @@ const internals = {
 
     return boomE;
   },
+
   oauthToBoom(oauthError) {
     // These little bits of code are stolen from oauth2orize
     // to translate raw Token/AuthorizationErrors to OAuth2 style errors
@@ -101,6 +121,7 @@ const internals = {
 
     return newResponse;
   },
+
   convertToExpress(request, reply) {
     request.yar.lazy(true);
 

--- a/server.js
+++ b/server.js
@@ -1,7 +1,5 @@
 /**
  * @module server
- *
- * Start up the Trails Application.Test
  */
 
 const newrelic = require('newrelic');


### PR DESCRIPTION
# HID-2136

Please check out the issue for a full description, but long story short I broke this part of HID for _some_ users (but not Drupal, which is why it was hard to track down). I'll comment inline with the major changes since I added tons of comments in the process of debugging.

## Testing

Since the "extra secure" flow is really difficult to mock, I have been using a local Drupal installation to test. I modified the port of HID to be 8080 and ran the drupal installation on port 80 without any modifications.

Once that is set up, log into Drupal as admin and adjust the `social_auth` config as desired to test various conditions (wrong client ID, wrong secret, etc).