### PR TITLE
HID-2190: create new OAuth client via jenkins command

### DIFF
--- a/commands/createOAuthClient.js
+++ b/commands/createOAuthClient.js
@@ -1,0 +1,85 @@
+/* eslint no-await-in-loop: "off", no-restricted-syntax: "off", no-console: "off" */
+/* eslint func-names: "off" */
+
+/**
+ * @module createOAuthClient
+ * @description Create OAuth client.
+ *
+ * docker-compose exec dev node ./commands/createOAuthClient.js
+ */
+const mongoose = require('mongoose');
+const args = require('yargs').argv;
+const app = require('../');
+const config = require('../config/env')[process.env.NODE_ENV];
+
+const { logger } = config;
+
+const store = app.config.env[process.env.NODE_ENV].database.stores[process.env.NODE_ENV];
+mongoose.connect(store.uri, store.options);
+
+const Client = require('../api/models/Client');
+
+// Generate a random secret each time we run the command
+const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()';
+let secret = '';
+for (let i = 0; i < 36; i++) {
+  secret += chars.charAt(Math.floor(Math.random() * chars.length));
+}
+
+async function run() {
+  const clientInfo = {
+    id: 'change-me',
+    name: 'CHANGE ME',
+    secret: secret,
+    url: 'https://example.com/',
+    redirectUri: 'https://example.com/user/login/hid/callback',
+  };
+
+  // Customize the input if arguments were sent
+  if (args.id) {
+    clientInfo.id = args.id;
+  }
+  if (args.name) {
+    clientInfo.name = args.name;
+  }
+  if (args.url) {
+    clientInfo.url = args.url;
+  }
+  if (args.redirectUri) {
+    clientInfo.redirectUri = args.redirectUri;
+  }
+
+  // Attempt to create new OAuth client and log the result.
+  await Client.create(clientInfo).then(data => {
+    logger.info(
+      '[commands->createOAuthClient] created new OAuth client',
+      {
+        security: true,
+        oauth: {
+          client_id: clientInfo.id,
+        },
+      },
+    );
+  }).catch(err => {
+    logger.warn(
+      '[commands->createOAuthClient] failed to create new OAuth client',
+      {
+        security: true,
+        fail: true,
+        oauth: {
+          client_id: clientInfo.id,
+        },
+        stack_trace: err.stack,
+      },
+    );
+  });
+
+  process.exit();
+}
+
+(async function () {
+  await run();
+}()).catch((e) => {
+  console.log(e);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-2190

we want to create new OAuth clients via jenkins. this new script at `commands/createOAuthClient.js` does that.

Testing locally is done by spinning up the container then running:

```
docker-compose exec dev node commands/createOAuthClient.js
```

It should log success or failure. Searching the list for "change" at http://api.hid.vm/admin will turn up the new entry like so:

<img width="651" alt="Screen Shot 2021-02-18 at 15 28 12" src="https://user-images.githubusercontent.com/254753/108372251-e73b7f00-71fe-11eb-964a-1badc69f9831.png">
