### PR TITLE
HID-2129: reduce response payload when account.json is requested

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -972,21 +972,9 @@ module.exports = {
       claims_supported: [
         'iss',
         'sub',
-        'aud',
-        'exp',
-        'iat',
         'name',
-        'given_name',
-        'family_name',
-        'middle_name',
-        'picture',
         'email',
         'email_verified',
-        'zoneinfo',
-        'locale',
-        'phone_number',
-        'phone_number_verified',
-        'updated_at',
       ],
     };
     return out;

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -968,7 +968,7 @@ module.exports = {
       response_types_supported: ['code', 'token', 'id_token', 'id_token token'],
       subject_types_supported: ['public'],
       id_token_signing_alg_values_supported: ['RS256'],
-      scopes_supported: ['openid', 'email', 'profile', 'phone'],
+      scopes_supported: ['openid', 'email', 'profile'],
       claims_supported: [
         'iss',
         'sub',

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -2317,7 +2317,6 @@ module.exports = {
 
     // This will be what we send back as a response.
     const output = {
-      _id: user._id.toString(),
       id: user.id,
       sub: user.id,
       email: user.email,
@@ -2345,9 +2344,6 @@ module.exports = {
     // Special cases for legacy compat.
     if (request.params.currentClient && (request.params.currentClient.id === 'iasc-prod' || request.params.currentClient.id === 'iasc-dev')) {
       output.sub = user.email;
-    }
-    if (request.params.currentClient && request.params.currentClient.id === 'dart-prod') {
-      delete output._id;
     }
     if (request.params.currentClient && request.params.currentClient.id === 'kaya-prod') {
       output.name = user.name.replace(' ', '');

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -2342,6 +2342,12 @@ module.exports = {
     );
 
     // Special cases for legacy compat.
+    //
+    // @TODO: in testing this, it seems that the `currentClient` param is not
+    //        present when this function runs. Investigate whether we need these
+    //        special cases at all.
+    //
+    //        @see https://humanitarian.atlassian.net/browse/HID-2192
     if (request.params.currentClient && (request.params.currentClient.id === 'iasc-prod' || request.params.currentClient.id === 'iasc-dev')) {
       output.sub = user.email;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.5",
+  "version": "3.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.5",
+  "version": "3.0.7",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-2129

I freely admit this is a change that should require a major version bump, but business-wise we've spent a year communicating this change to our partner websites so I'm cheating a little bit.

Our `account.json` response is being reduced from the entire DB record, to the few fields that are necessary for OAuth to function:

- `id`: HID user ID
- `sub`: defined by OAuth spec to be your unique identifier (internally we duplicate the `id` field)
- `email`: I think this is self-explanatory
- `email_verified`: defined by OAuth spec to report whether the user demonstrated ownership of the account in the `email` field
- `name`: the name of the user
- `iss`: canonical URL of our OAuth service

The OpenID Connect config has also been pruned to reflect our new payload. If we need such properties as `exp`, `iat` or others that OpenID defines, I'll be glad to add them back in. However, our existing response didn't include them so I'm not expecting it to break with them gone. /cc @attiks in case I've overlooked something on the Drupal side in this regard.

## Testing

The testing ideally involves a local drupal instance. I ran my local HID on a different port and let drupal be on 80. The `social_auth` can be configured to accept a new URL including the port.

To get the two talking, I ran `docker-compose exec drupal /sbin/ip route|awk '/default/ { print $3 }'` to get the IP of the host as defined in the drupal container, then set `api.hid.vm` to that IP in the drupal container's `/etc/hosts`

Config on either HID or Drupal might need to be adjusted so that `client_secret` and stuff matches up.

When I did local testing, I was able to log in as myself _with a pre-existing account_ — that is, I had logged into the local Drupal beforehand using local HID on `dev` branch, and then once this PR's branch was checked out, doing a fresh HID login still worked. That's the primary use-case since we have dozens of Drupal sites already operating on old HID, and we want to ensure people still log in as themselves once this is deployed.