### PR TITLE
HID-1919: remove emailsVisibility field from all users

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -265,11 +265,6 @@ const UserSchema = new Schema({
     type: [emailSchema],
     // readonly: true
   },
-  emailsVisibility: {
-    type: String,
-    enum: visibilities,
-    default: 'anyone',
-  },
   password: {
     type: String,
   },
@@ -641,13 +636,8 @@ UserSchema.statics = {
   sanitizeExportedUser(auser, requester) {
     const user = auser;
     if (user._id.toString() !== requester._id.toString() && !requester.is_admin) {
-      if (user.emailsVisibility !== 'anyone') {
-        if ((user.emailsVisibility === 'verified' && !requester.verified)
-        || (user.emailsVisibility === 'connections' && this.connectionsIndex(user, requester._id) === -1)) {
-          user.email = null;
-          user.emails = [];
-        }
-      }
+      user.email = null;
+      user.emails = [];
 
       if (user.locationsVisibility !== 'anyone') {
         if ((user.locationsVisibility === 'verified' && !requester.verified)
@@ -738,13 +728,8 @@ UserSchema.methods = {
     this.sanitizeClients();
     this.sanitizeLists(user);
     if (this._id && user._id && this._id.toString() !== user._id.toString() && !user.is_admin) {
-      if (this.emailsVisibility !== 'anyone') {
-        if ((this.emailsVisibility === 'verified' && !user.verified)
-        || (this.emailsVisibility === 'connections' && this.connectionsIndex(user._id) === -1)) {
-          this.email = null;
-          this.emails = [];
-        }
-      }
+      this.email = null;
+      this.emails = [];
 
       if (this.locationsVisibility !== 'anyone') {
         if ((this.locationsVisibility === 'verified' && !user.verified)

--- a/commands/removeFieldEmailsVisibility.js
+++ b/commands/removeFieldEmailsVisibility.js
@@ -1,0 +1,59 @@
+/**
+ * @module removeFieldEmailsVisibility
+ * @description Permanently removes the emailsVisibility field from all users.
+ */
+const mongoose = require('mongoose');
+const app = require('../');
+const config = require('../config/env')[process.env.NODE_ENV];
+
+const { logger } = config;
+
+// Connect to DB
+const store = app.config.env[process.env.NODE_ENV].database.stores[process.env.NODE_ENV];
+mongoose.connect(store.uri, store.options);
+
+// Load User model
+const User = require('../api/models/User');
+
+async function run() {
+  // Drop `emailsVisibility` from all users.
+  await User.collection.updateMany({}, {
+    $unset: {
+      'emailsVisibility': 1,
+    },
+  }).catch(err => {
+    logger.warn(
+      `[commands->removeFieldEmailsVisibility] ${err.message}`,
+      {
+        migration: true,
+        fail: true,
+        stack_trace: err.stack,
+      },
+    );
+  });
+
+  // Log it
+  logger.info(
+    '[commands->removeFieldEmailsVisibility] Removed emailsVisibility field from all users',
+    {
+      migration: true,
+    },
+  );
+
+  // We're done.
+  process.exit();
+}
+
+(async function () {
+  await run();
+}()).catch(err => {
+  logger.error(
+    `[commands->removeFieldEmailsVisibility] ${err.message}`,
+    {
+      migration: true,
+      fail: true,
+      stack_trace: err.stack,
+    },
+  );
+  process.exit(1);
+});

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -63,9 +63,6 @@ components:
         email_verified:
           type: string
           description: 'Whether the user primary email is verified'
-        emailsVisibility:
-          type: string
-          description: 'Who can view this user emails'
         expires:
           type: string
           format: date-time

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-1919

Removes the `emailsVisibility` field. Field remains in CSV export and GSSSync functions.

```
$ docker-compose exec dev node commands/removeFieldEmailsVisibility.js
info: [commands->removeFieldEmailsVisibility] Removed emailsVisibility field from all users level=info, @timestamp=2021-02-23T10:09:34.514Z, ,

$ docker-compose exec db mongo local
> db.user.count({emailsVisibility: {$exists: true}})
0
```

OAuth should still work like usual.