### PR TITLE
HID-1921: remove websites field from all users

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -321,26 +321,6 @@ const UserSchema = new Schema({
       message: 'HTML code is not allowed in notes',
     },
   },
-  // Validates urls
-  websites: {
-    type: Array,
-    validate: {
-      validator(v) {
-        if (v.length) {
-          let out = true;
-          const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/;
-          for (let i = 0, len = v.length; i < len; i += 1) {
-            if (!urlRegex.test(v[i].url)) {
-              out = false;
-            }
-          }
-          return out;
-        }
-        return true;
-      },
-      message: 'There is an invalid url',
-    },
-  },
   // TODO: validate timezone
   zoneinfo: {
     type: String,

--- a/commands/removeFieldWebsites.js
+++ b/commands/removeFieldWebsites.js
@@ -1,0 +1,59 @@
+/**
+ * @module removeFieldWebsites
+ * @description Permanently removes the websites field from all users.
+ */
+const mongoose = require('mongoose');
+const app = require('../');
+const config = require('../config/env')[process.env.NODE_ENV];
+
+const { logger } = config;
+
+// Connect to DB
+const store = app.config.env[process.env.NODE_ENV].database.stores[process.env.NODE_ENV];
+mongoose.connect(store.uri, store.options);
+
+// Load User model
+const User = require('../api/models/User');
+
+async function run() {
+  // Drop `websites` from all users.
+  await User.collection.updateMany({}, {
+    $unset: {
+      'websites': 1,
+    },
+  }).catch(err => {
+    logger.warn(
+      `[commands->removeFieldWebsites] ${err.message}`,
+      {
+        migration: true,
+        fail: true,
+        stack_trace: err.stack,
+      },
+    );
+  });
+
+  // Log it
+  logger.info(
+    '[commands->removeFieldWebsites] Removed websites field from all users',
+    {
+      migration: true,
+    },
+  );
+
+  // We're done.
+  process.exit();
+}
+
+(async function () {
+  await run();
+}()).catch(err => {
+  logger.error(
+    `[commands->removeFieldWebsites] ${err.message}`,
+    {
+      migration: true,
+      fail: true,
+      stack_trace: err.stack,
+    },
+  );
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.15",
+  "version": "3.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.15",
+  "version": "3.0.17",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-1921

Removes the `websites` field from user profiles.

```
$ docker-compose exec dev node commands/removeFieldWebsites.js
info: [commands->removeFieldWebsites] Removed websites field from all users level=info, @timestamp=2021-02-23T10:25:14.228Z, ,

$ docker-compose exec db mongo local
> db.user.count({websites: {$exists: true}})
0
```

OAuth logins should stop working.... not really, just seeing if you read the description 😆 