### PR TITLE
HID-1939: remove location, locations, locationsVisibility fields

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -387,29 +387,6 @@ const UserSchema = new Schema({
     },
   },
   functional_roles: [listUserSchema],
-  // TODO: figure out validation
-  location: {
-    type: Schema.Types.Mixed,
-    /* validate: validate({
-    validator: 'isJSON',
-    passIfEmpty: true,
-    message: 'location should be valid JSON'
-  }) */
-  },
-  // TODO: figure out validation
-  locations: {
-    type: Array,
-    /* validate: validate({
-    validator: 'isJSON',
-    passIfEmpty: true,
-    message: 'locations should be valid JSON'
-  }) */
-  },
-  locationsVisibility: {
-    type: String,
-    enum: visibilities,
-    default: 'anyone',
-  },
   // Only an admin can set this
   is_admin: {
     type: Boolean,
@@ -648,14 +625,6 @@ UserSchema.statics = {
           user.emails = [];
         }
       }
-
-      if (user.locationsVisibility !== 'anyone') {
-        if ((user.locationsVisibility === 'verified' && !requester.verified)
-        || (user.locationsVisibility === 'connections' && this.connectionsIndex(user, requester._id) === -1)) {
-          user.location = null;
-          user.locations = [];
-        }
-      }
     }
   },
 
@@ -743,14 +712,6 @@ UserSchema.methods = {
         || (this.emailsVisibility === 'connections' && this.connectionsIndex(user._id) === -1)) {
           this.email = null;
           this.emails = [];
-        }
-      }
-
-      if (this.locationsVisibility !== 'anyone') {
-        if ((this.locationsVisibility === 'verified' && !user.verified)
-        || (this.locationsVisibility === 'connections' && this.connectionsIndex(user._id) === -1)) {
-          this.location = null;
-          this.locations = [];
         }
       }
     }
@@ -1001,15 +962,6 @@ UserSchema.methods = {
       return true;
     }
     return false;
-  },
-
-  // Whether the contact is in country or not
-  async isInCountry(pcode) {
-    const hrinfoId = this.location.country.id.replace('hrinfo_loc_', '');
-    const url = `https://www.humanitarianresponse.info/api/v1.0/locations/${hrinfoId}`;
-    const response = await axios.get(url);
-    const parsed = JSON.parse(response.data);
-    return parsed.data[0].pcode === pcode;
   },
 
   translateCheckin(acheckin, language) {

--- a/commands/removeFieldLocations.js
+++ b/commands/removeFieldLocations.js
@@ -1,0 +1,62 @@
+/**
+ * @module removeFieldLocations
+ * @description Permanently removes the location, locations, locationsVisibility
+ * fields from all users.
+ */
+const mongoose = require('mongoose');
+const app = require('../');
+const config = require('../config/env')[process.env.NODE_ENV];
+
+const { logger } = config;
+
+// Connect to DB
+const store = app.config.env[process.env.NODE_ENV].database.stores[process.env.NODE_ENV];
+mongoose.connect(store.uri, store.options);
+
+// Load User model
+const User = require('../api/models/User');
+
+async function run() {
+  // Drop location, locations, locationsVisibility fields from all users.
+  await User.collection.updateMany({}, {
+    $unset: {
+      'location': 1,
+      'locations': 1,
+      'locationsVisibility': 1,
+    },
+  }).catch(err => {
+    logger.warn(
+      `[commands->removeFieldLocations] ${err.message}`,
+      {
+        migration: true,
+        fail: true,
+        stack_trace: err.stack,
+      },
+    );
+  });
+
+  // Log it
+  logger.info(
+    '[commands->removeFieldLocations] Removed location, locations, locationsVisibility fields from all users',
+    {
+      migration: true,
+    },
+  );
+
+  // We're done.
+  process.exit();
+}
+
+(async function () {
+  await run();
+}()).catch(err => {
+  logger.error(
+    `[commands->removeFieldLocations] ${err.message}`,
+    {
+      migration: true,
+      fail: true,
+      stack_trace: err.stack,
+    },
+  );
+  process.exit(1);
+});

--- a/commands/sendReminderCheckinEmails.js
+++ b/commands/sendReminderCheckinEmails.js
@@ -29,7 +29,7 @@ async function run() {
         && offset < 72 * 3600 * 1000
         && !lu.deleted) {
         const hasLocalPhoneNumber = false;
-        const inCountry = await user.isInCountry(lu.list.metadata.country.pcode);
+        const inCountry = false;
         lu.remindedCheckin = true;
         await user.save();
       }

--- a/commands/sendReminderCheckinEmails.js
+++ b/commands/sendReminderCheckinEmails.js
@@ -28,7 +28,6 @@ async function run() {
       if (!lu.remindedCheckin && offset > 48 * 3600 * 1000
         && offset < 72 * 3600 * 1000
         && !lu.deleted) {
-        const hasLocalPhoneNumber = false;
         lu.remindedCheckin = true;
         await user.save();
       }

--- a/commands/sendReminderCheckinEmails.js
+++ b/commands/sendReminderCheckinEmails.js
@@ -2,8 +2,8 @@
 /* eslint func-names: "off" */
 /**
  * @module sendReminderCheckinEmails
- * @description Sends a notification to users who checked into a list more than 48 hours ago and
- * didn't update their contact details.
+ * @description Sends a notification to users who checked into a list more than
+ * 48 hours ago and didn't update their contact details.
  */
 
 const mongoose = require('mongoose');
@@ -29,7 +29,6 @@ async function run() {
         && offset < 72 * 3600 * 1000
         && !lu.deleted) {
         const hasLocalPhoneNumber = false;
-        const inCountry = false;
         lu.remindedCheckin = true;
         await user.save();
       }

--- a/emails/reminder_checkin/fr/html.ejs
+++ b/emails/reminder_checkin/fr/html.ejs
@@ -6,10 +6,6 @@
 <p>Nous avons remarqué que vous n'avez pas encore ajouté de numéro de téléphone local. Si vous en avez un et que vous souhaitez l'ajouter, mettez à jour votre profil (voir lien ci-dessous).</p>
 <% } %>
 
-<% if (!inCountry) { %>
-<p>Nous avons <% if (!hasLocalPhoneNumber) { %> aussi <% } %> remarqué que vous avez spécifié <%= user.location.country.name %> comme pays dans lequel vous vous trouvez actuellement. Si vous êtes en/au <a href="<%= params.list.getAppUrl() %>"><%= params.list.name %></a>, nous vous prions de bien vouloir mettre à jour votre pays. Si vous êtes effectivement basé en/au <%= user.location.country.name %>, vous pouvez ignorer cette requête - nous savons que des humanitaires répondent à des crises à distance.</p>
-<% } %>
-
 <p>La possibilité pour les humanitaires de se trouver et se contacter durant une crise est extrêmement importante. Humanitarian ID adopte une approche décentralisée des listes de contact et compte donc sur ses membres tels que vous pour aider à maintenir les listes de contact à jour.</p>
 
 <% include ../../includes/footer_fr %>

--- a/emails/reminder_checkin/fr/html.ejs
+++ b/emails/reminder_checkin/fr/html.ejs
@@ -2,10 +2,6 @@
 
 <p>Merci de vous être inscrit à <a href="<%= params.list.getAppUrl() %>"><%= params.list.name %></a> il y a deux jours. Vous pouvez maintenant trouver les informations de contacts des autres humanitaires.</p>
 
-<% if (!hasLocalPhoneNumber) { %>
-<p>Nous avons remarqué que vous n'avez pas encore ajouté de numéro de téléphone local. Si vous en avez un et que vous souhaitez l'ajouter, mettez à jour votre profil (voir lien ci-dessous).</p>
-<% } %>
-
 <p>La possibilité pour les humanitaires de se trouver et se contacter durant une crise est extrêmement importante. Humanitarian ID adopte une approche décentralisée des listes de contact et compte donc sur ses membres tels que vous pour aider à maintenir les listes de contact à jour.</p>
 
 <% include ../../includes/footer_fr %>

--- a/emails/reminder_checkin/html.ejs
+++ b/emails/reminder_checkin/html.ejs
@@ -2,10 +2,6 @@
 
 <p>Thank you for checking into <a href="<%= params.list.getAppUrl() %>"><%= params.list.name %></a> two days ago. You can now find contact details of other humanitarians.</p>
 
-<% if (!hasLocalPhoneNumber) { %>
-<p>We noticed that you have not yet added a local phone number. If you have one and would like to add it, simply  update your profile.</p>
-<% } %>
-
 <p>The ability for responders to find and connect during a humanitarian crisis is of utmost importance. Humanitarian ID takes a decentralized approach to contact lists and thus relies on members like yourself to help keep these lists up-to-date.</p>
 
 <% include ../includes/footer_en %>

--- a/emails/reminder_checkin/html.ejs
+++ b/emails/reminder_checkin/html.ejs
@@ -6,10 +6,6 @@
 <p>We noticed that you have not yet added a local phone number. If you have one and would like to add it, simply  update your profile.</p>
 <% } %>
 
-<% if (!inCountry) { %>
-<p>We <% if (!hasLocalPhoneNumber) { %> also <% } %> noticed that you have specified <%= user.location.country.name %>. If you are in <a href="<%= params.list.getAppUrl() %>"><%= params.list.name %></a>, we ask that you kindly update your location details in your profile using the link below. If you are indeed based in <%= user.location.country.name %>, simply ignore this request - we know that people support emergencies remotely.</p>
-<% } %>
-
 <p>The ability for responders to find and connect during a humanitarian crisis is of utmost importance. Humanitarian ID takes a decentralized approach to contact lists and thus relies on members like yourself to help keep these lists up-to-date.</p>
 
 <% include ../includes/footer_en %>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.15",
+  "version": "3.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.15",
+  "version": "3.0.18",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-1939

Removes the `location`, `locations`, and `locationsVisibility` fields from all user profiles. References remain in Outlook, GSS, and CSV export functions.

```
$ docker-compose exec dev node commands/removeFieldLocations.js
info: [commands->removeFieldLocations] Removed location, locations, locationsVisibility fields from all users level=info, @timestamp=2021-02-23T10:43:01.206Z, ,

$ docker-compose exec db mongo local
> db.user.count({location: {$exists: true}})
0
> db.user.count({locations: {$exists: true}})
0
> db.user.count({locationsVisibility: {$exists: true}})
0
```

OAuth should continue working as usual.