### PR TITLE
HID-2193: remove functional_roles field from all users

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -386,7 +386,6 @@ const UserSchema = new Schema({
       message: 'HTML in job titles is not allowed',
     },
   },
-  functional_roles: [listUserSchema],
   // TODO: figure out validation
   location: {
     type: Schema.Types.Mixed,
@@ -543,7 +542,6 @@ UserSchema.index({ 'bundles.list': 1 });
 UserSchema.index({ 'disasters.list': 1 });
 UserSchema.index({ 'offices.list': 1 });
 UserSchema.index({ 'organizations.list': 1 });
-UserSchema.index({ 'functional_roles.list': 1 });
 
 /* eslint prefer-arrow-callback: "off", func-names: "off" */
 UserSchema.virtual('sub').get(function () {
@@ -633,7 +631,6 @@ UserSchema.statics = {
       'disasters',
       'organization',
       'organizations',
-      'functional_roles',
       'offices',
     ];
   },

--- a/commands/removeFieldFunctionalRoles.js
+++ b/commands/removeFieldFunctionalRoles.js
@@ -1,0 +1,59 @@
+/**
+ * @module removeFieldFunctionalRoles
+ * @description Permanently removes the functional_roles field from all users.
+ */
+const mongoose = require('mongoose');
+const app = require('../');
+const config = require('../config/env')[process.env.NODE_ENV];
+
+const { logger } = config;
+
+// Connect to DB
+const store = app.config.env[process.env.NODE_ENV].database.stores[process.env.NODE_ENV];
+mongoose.connect(store.uri, store.options);
+
+// Load User model
+const User = require('../api/models/User');
+
+async function run() {
+  // Drop `functional_roles` from all users.
+  await User.collection.updateMany({}, {
+    $unset: {
+      'functional_roles': 1,
+    },
+  }).catch(err => {
+    logger.warn(
+      `[commands->removeFieldFunctionalRoles] ${err.message}`,
+      {
+        migration: true,
+        fail: true,
+        stack_trace: err.stack,
+      },
+    );
+  });
+
+  // Log it
+  logger.info(
+    '[commands->removeFieldFunctionalRoles] Removed functional_roles field from all users',
+    {
+      migration: true,
+    },
+  );
+
+  // We're done.
+  process.exit();
+}
+
+(async function () {
+  await run();
+}()).catch(err => {
+  logger.error(
+    `[commands->removeFieldFunctionalRoles] ${err.message}`,
+    {
+      migration: true,
+      fail: true,
+      stack_trace: err.stack,
+    },
+  );
+  process.exit(1);
+});

--- a/commands/updateListUsers.js
+++ b/commands/updateListUsers.js
@@ -24,7 +24,6 @@ async function run() {
       { path: 'disasters.list' },
       { path: 'organization.list' },
       { path: 'organizations.list' },
-      { path: 'functional_roles.list' },
       { path: 'offices.list' },
     ])
     .cursor();

--- a/config/routes.js
+++ b/config/routes.js
@@ -42,7 +42,6 @@ const childAttributes = [
   'lists',
   'organization',
   'organizations',
-  'functional_roles',
   'offices',
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.15",
+  "version": "3.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.0.15",
+  "version": "3.0.19",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-2193

Removes the `functional_roles` field from User schema, and code remains in the CSV, GSS, Outlook vestigial functions.

```
$ docker-compose exec dev node commands/removeFieldFunctionalRoles.js
info: [commands->removeFieldFunctionalRoles] Removed functional_roles field from all users level=info, @timestamp=2021-02-23T12:50:55.829Z, ,

$ docker-compose exec db mongo local
> db.user.count({functional_roles: {$exists: true}})
0
```

OAuth should still work.

Feeling like I should tackle these GSS and CSV things so I can stop sounding like a broken record 😆 