### PR TITLE
HID-2173: add some about text to login page

### DIFF
--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -1,0 +1,9 @@
+/**
+ * Login page
+ */
+.page--login {}
+
+.page--login .cd-grid > * {
+  display: block;
+  background: transparent;
+}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,9 +1,11 @@
 <% include header %>
+<style><% include ../assets/css/cd-grid.css %></style>
+<style><% include ../assets/css/login.css %></style>
 
-<div class="api-page">
-  <main role="main" id="main-content" class="cd-container">
-    <div class="cd-layout-content">
-      <div class="[ flow ]">
+<main role="main" id="main-content" class="cd-container page--login">
+  <div class="cd-layout-content">
+    <div class="cd-grid cd-grid-2-col">
+      <div class="cd-grid__col">
         <h1 class="page-header__heading">Log in</h1>
 
         <% include alert.html %>
@@ -35,7 +37,13 @@
         <p><a href="<%= registerLink %>">Register a new Humanitarian ID Account</a></p>
         <p><a href="<%= passwordLink %>">Forgot/Reset password</a></p>
       </div>
+      <div class="cd-grid__col">
+        <h1 class="page-header__heading">What is Humanitarian ID?</h1>
+        <p>Humanitarian ID is an authentication service managed by the United Nations Office for the Coordination of Humanitarian Affairs (UNOCHA).</p>
+        <p>The service is provided freely to the humanitarian community. More information is available at <a href="https://about.humanitarian.id">about.humanitarian.id</a> and our team can be contacted at <a href="mailto:info@humanitarian.id">info@humanitarian.id</a></p>
+      </div>
     </div>
-  </main>
-</div>
+  </div>
+</main>
+
 <% include footer %>


### PR DESCRIPTION
# HID-2173

Adding some "about this site" text to the login form, which currently functions as homepage. People who log into other sites with HID will also see this text next to or under the login form.

@left23 I had a question about the Grid in flowdock but though I'd tag you as a reviewer so you can advise me on specific lines if I am implementing the grid wrong. I'll leave a comment on my workaround I added.