### PR TITLE
OPS-7348: revert the auto-incrementing version in API Docs

### DIFF
--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: <<<VERSION>>>
+  version: 3.1.4
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",
@@ -13,7 +13,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "node ./node_modules/nodemon/bin/nodemon.js ./server.js -e html,css,js,ejs",
-    "docs": "node ./commands/__swaggerVersion.js && swagger-inline './api/**/*' --base 'docs/swaggerBase.yaml' > docs/hid.yml",
+    "docs": "swagger-inline './api/**/*' --base 'docs/swaggerBase.yaml' > docs/hid.yml",
     "start": "node ./server.js",
     "test": "eslint ."
   },


### PR DESCRIPTION
# OPS-7348

I borked the DockerHub image builder and didn't know until now. This script, combined with our weird method of requiring config that uses relative paths, is breaking on account.

Fixing the DockerHub regression caused by 325a7ed