### PR TITLE
HID-2209: remove trailing slashes in CD Footer

### DIFF
--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 3.1.5
+  version: 3.1.6
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",

--- a/templates/footer.ejs
+++ b/templates/footer.ejs
@@ -8,13 +8,13 @@
                 <a href="https://about.humanitarian.id/" class="footer-links__link" translate>About</a>
               </li>
               <li class="menu-item footer-links__item">
-                <a href="https://about.humanitarian.id/developers/" class="footer-links__link" translate>Developers</a>
+                <a href="https://about.humanitarian.id/developers" class="footer-links__link" translate>Developers</a>
               </li>
               <li class="menu-item footer-links__item">
-                <a href="https://about.humanitarian.id/code-of-conduct/" class="footer-links__link" translate>Code of conduct</a>
+                <a href="https://about.humanitarian.id/code-of-conduct" class="footer-links__link" translate>Code of conduct</a>
               </li>
               <li class="menu-item footer-links__item">
-                <a href="https://about.humanitarian.id/terms-of-service/" class="footer-links__link" translate>Terms of Service</a>
+                <a href="https://about.humanitarian.id/terms-of-service" class="footer-links__link" translate>Terms of Service</a>
               </li>
               <li class="menu-item footer-links__item last">
                 <a href="mailto:info@humanitarian.id" class="footer-links__link" translate>Contact</a>


### PR DESCRIPTION
# HID-2209

The trailing slashes weren't compatible with some URLs on GH Pages. Removing them all.