### PR TITLE
HID-2211: add slashes to manually-constructed top-level URLs

### DIFF
--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -819,7 +819,7 @@ module.exports = {
           : '';
       const clientUrl = URL.parse(tmpUrl);
       client.urlDisplay = clientUrl.hostname;
-      client.urlHref = clientUrl.protocol + clientUrl.hostname;
+      client.urlHref = `${clientUrl.protocol}//${clientUrl.hostname}`;
     });
 
     // Render settings page.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-2211

Small templating change with big effects on end-users. Their settings pages will now properly link to individual OAuth Client URLs. There was no security problem here because the bug's affect was to link to https://auth.humanitarian.id/someurl.org which 404s on HID and looks ugly, but never sent people to a strange place on the internet.

## Testing

Load your user settings where it lists your authorized OAuth Clients and view source to manually verify that URLs are well-formatted. They were already working fine during local testing which allowed this bug to slip through. Click one or two and confirm that they still link to the intended location.