### PR TITLE
HID-2210: log human-friendly OAuth Client ID when new authorization happens

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -730,7 +730,8 @@ module.exports = {
       request.auth.credentials = user;
 
       // Set up OAuth Client to potentially be stored on user profile.
-      const clientId = request.yar.authorize[request.payload.transaction_id].client;
+      const clientMongoId = request.yar.authorize[request.payload.transaction_id].client;
+      const clientId = request.yar.authorize[request.payload.transaction_id].req.clientID;
 
       // If user clicked 'Deny', redirect to HID homepage.
       if (!request.payload.bsubmit || request.payload.bsubmit === 'Deny') {
@@ -738,13 +739,13 @@ module.exports = {
       }
 
       // If the user clicked 'Allow', save OAuth Client to user profile
-      if (!user.hasAuthorizedClient(clientId) && request.payload.bsubmit === 'Allow') {
+      if (!user.hasAuthorizedClient(clientMongoId) && request.payload.bsubmit === 'Allow') {
         // TODO: we could store an array of objects including the current time
         //       when adding the client, in order to offer security-related info
         //       when the user views their OAuth settings.
         //
         // @see HID-2156
-        user.authorizedClients.push(request.yar.authorize[request.payload.transaction_id].client);
+        user.authorizedClients.push(clientMongoId);
         user.markModified('authorizedClients');
         await user.save();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-2210

I was logging the wrong value for `hid.oauth.client_id` in Kibana. Now it will log something like `ocha-gho-local` instead of a 24-char hex string.