### PR TITLE
HID-2217: remove browser autocomplete for new passwords

### DIFF
--- a/templates/new_password.html
+++ b/templates/new_password.html
@@ -13,7 +13,7 @@
               type="password"
               name="password"
               id="password"
-              autocomplete="new-password"
+              autocomplete="off"
               required
               minlength="12"
               pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
@@ -25,7 +25,7 @@
               type="password"
               name="confirm_password"
               id="confirm_password"
-              autocomplete="new-password"
+              autocomplete="off"
               required
               minlength="12"
               pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"

--- a/templates/register.html
+++ b/templates/register.html
@@ -28,7 +28,7 @@
             type="password"
             name="password"
             id="password"
-            autocomplete="new-password"
+            autocomplete="off"
             required
             minlength="12"
             pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
@@ -40,7 +40,7 @@
             type="password"
             name="confirm_password"
             id="confirm_password"
-            autocomplete="new-password"
+            autocomplete="off"
             required
             minlength="12"
             pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"

--- a/templates/settings-password.html
+++ b/templates/settings-password.html
@@ -58,7 +58,7 @@
                   type="password"
                   name="new_password"
                   id="password"
-                  autocomplete="new-password"
+                  autocomplete="off"
                   required
                   minlength="12"
                   pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"
@@ -70,7 +70,7 @@
                   type="password"
                   name="confirm_password"
                   id="confirm_password"
-                  autocomplete="new-password"
+                  autocomplete="off"
                   required
                   minlength="12"
                   pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$"


### PR DESCRIPTION
# HID-2217

Removing autocomplete from new-password fields. There's basically nothing to test given that this is browser-facing HTML, but go ahead and run the Login E2E if you want.