### PR TITLE
HID-2218: ensure API docs work by default

### DIFF
--- a/config/web.js
+++ b/config/web.js
@@ -120,6 +120,8 @@ module.exports = {
           'self',
           'https://www.google-analytics.com',
           'https://stats.g.doubleclick.net',
+          // API Docs connect to Stage by default
+          'https://stage.api-humanitarian-id.ahconu.org',
         ],
         imgSrc: [
           'self',


### PR DESCRIPTION
# HID-2218

Stage is our default environment and it needs to be allowed.