### PR TITLE
HID-2202: CD Tag labels instead of disabled buttons

### DIFF
--- a/assets/css/cd-tag.css
+++ b/assets/css/cd-tag.css
@@ -108,5 +108,5 @@
   --cd-tag--color: #71dbd4;
 }
 .cd-tag--color-6 {
-  --cd-tag--color: #7043ad;
+  --cd-tag--color: #9063cd;
 }

--- a/assets/css/cd-tag.css
+++ b/assets/css/cd-tag.css
@@ -1,10 +1,15 @@
-/* https://raw.githubusercontent.com/UN-OCHA/common_design/v4.0.2/components/cd-tag/cd-tag.css */
+/**
+ * CD Tag
+ * @see https://raw.githubusercontent.com/UN-OCHA/common_design/v4.0.2/components/cd-tag/cd-tag.css
+ *
+ * Minor modifications were made to accomodate a11y feedback from automated tools.
+ */
 
 /**
  * Root vars for CD Tag
  */
 :root {
-  --cd-tag--color: #5090cd;
+  --cd-tag--color: #3070ad;
 }
 
 /**
@@ -103,5 +108,5 @@
   --cd-tag--color: #71dbd4;
 }
 .cd-tag--color-6 {
-  --cd-tag--color: #9063cd;
+  --cd-tag--color: #7043ad;
 }

--- a/assets/css/cd-tag.css
+++ b/assets/css/cd-tag.css
@@ -1,0 +1,107 @@
+/* https://raw.githubusercontent.com/UN-OCHA/common_design/v4.0.2/components/cd-tag/cd-tag.css */
+
+/**
+ * Root vars for CD Tag
+ */
+:root {
+  --cd-tag--color: #5090cd;
+}
+
+/**
+ * Base component styles for the collection of tags
+ */
+.cd-tags {
+  /* Override container class if you wish to provide specific styling to all tags */
+}
+
+/**
+ * Individual tag
+ *
+ * - margin is set in `rem` to ensure that multiple tag sizes visually line up
+ * - all other units are `em` so that setting `font-size` can scale them easily
+ */
+.cd-tag {
+  display: inline-block;
+  margin: 0.25rem;
+  padding: 0 0.25em;
+  text-align: center;
+  vertical-align: top;
+  text-transform: uppercase;
+  color: var(--cd-white);
+  background-color: var(--cd-tag--color);
+  font-size: 0.625em;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
+/**
+ * Variants
+ *
+ * You might call each tag a variant, but they do tend to correspond to content
+ * in the DB instead of exportable config that we can store in version control.
+ *
+ * Therefore, the following rules will serve as an example, and would probably
+ * be implemented in the primary active theme of a website. Additionally, some
+ * colors were defined in the example HTML to simulate a sub-theme or other
+ * site-specific theme providing those styles.
+ */
+
+/**
+ * Variant: rounded
+ *
+ * The business owner loves rounded corners.
+ */
+.cd-tag--rounded {
+  border-radius: 3px;
+}
+
+/**
+ * Variant: linked
+ *
+ * Some tags are links.
+ */
+.cd-tag--linked a {
+  text-decoration: underline;
+  color: inherit;
+}
+.cd-tag--linked a:hover {
+  text-decoration: none;
+  color: inherit;
+}
+
+/**
+ * Variant: large
+ */
+.cd-tag--large {
+  font-size: 1em;
+}
+
+/**
+ * Variant: huge
+ */
+.cd-tag--xl {
+  font-size: 1.5em;
+}
+
+/**
+ * Custom colors
+ */
+.cd-tag--color-1 {
+  --cd-tag--color: #65c296;
+}
+.cd-tag--color-2 {
+  --cd-tag--color: #eca154;
+}
+.cd-tag--color-3 {
+  --cd-tag--color: #e2e868;
+  color: var(--cd-black);
+}
+.cd-tag--color-4 {
+  --cd-tag--color: #a4d65e;
+}
+.cd-tag--color-5 {
+  --cd-tag--color: #71dbd4;
+}
+.cd-tag--color-6 {
+  --cd-tag--color: #9063cd;
+}

--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -201,9 +201,8 @@ textarea {
 }
 
 input:focus {
-  outline: 2px solid var(--cd-bright-blue);
-  outline-offset: 1px;
-  box-shadow: none
+  outline: 0;
+  box-shadow: 0 0 0 2px black;
 }
 
 input:focus:invalid {

--- a/assets/css/profile-edit.css
+++ b/assets/css/profile-edit.css
@@ -61,9 +61,3 @@
 .profile__email .email__delete {
   padding-left: 1em;
 }
-
-.form-actions .cd-button {
-  /* we have a link styled like a back button, plus a real button. they have
-  different line-heights due to normalize.css not resetting links */
-  line-height: 1.15;
-}

--- a/assets/css/profile-edit.css
+++ b/assets/css/profile-edit.css
@@ -47,6 +47,9 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.cd-tag {
+  font-size: 0.675em;
+}
 .profile__email .email__address--unconfirmed {
   color: #444;
   font-style: italic;

--- a/assets/css/profile-show.css
+++ b/assets/css/profile-show.css
@@ -16,3 +16,6 @@
 .email__address label {
   padding-right: 1rem;
 }
+.cd-tag {
+  font-size: 0.675em;
+}

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -47,7 +47,7 @@
                 </div>
                 <div class="email__delete">
                   <% if (user.email === thisEmail.email) { %>
-                    <span class="cd-tag cd-tag--rounded cd-tag--color-6">Primary</span>
+                    <span class="cd-tag cd-tag--rounded">Primary</span>
                   <% } else { %>
                     <button
                       type="submit"

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -1,4 +1,5 @@
 <% include header %>
+<link rel="stylesheet" href="/assets/css/cd-tag.css">
 <link rel="stylesheet" href="/assets/css/profile-edit.css">
 
 <div class="api-page">
@@ -46,7 +47,7 @@
                 </div>
                 <div class="email__delete">
                   <% if (user.email === thisEmail.email) { %>
-                    <button disabled class="cd-button cd-button--small cd-button--bold cd-button--uppercase">Primary</button>
+                    <span class="cd-tag cd-tag--rounded cd-tag--color-6">Primary</span>
                   <% } else { %>
                     <button
                       type="submit"

--- a/templates/profile-show.html
+++ b/templates/profile-show.html
@@ -1,6 +1,7 @@
 <% include header %>
 <link rel="stylesheet" href="/assets/css/cd-grid.css">
 <link rel="stylesheet" href="/assets/css/cd-card.css">
+<link rel="stylesheet" href="/assets/css/cd-tag.css">
 <link rel="stylesheet" href="/assets/css/profile-show.css">
 
 <div class="api-page">
@@ -34,7 +35,7 @@
                       <div class="email__address">
                         <label><%= user.email %></label>
                         <div class="email__status">
-                          <button disabled class="cd-button cd-button--small cd-button--bold cd-button--uppercase">Primary</button>
+                          <span class="cd-tag cd-tag--rounded cd-tag--color-6">Primary</span>
                         </div>
                       </div>
                     </div>
@@ -43,9 +44,9 @@
                       <div class="email__address">
                         <label><%= email.email %></label>
                         <div class="email__status">
-                          <button disabled class="cd-button cd-button--small cd-button--outline cd-button--bold cd-button--uppercase">
+                          <span class="cd-tag cd-tag--rounded">
                             <%= email.validated === true ? 'confirmed' : 'not confirmed' %>
-                          </button>
+                          </span>
                         </div>
                       </div>
                     </div>

--- a/templates/profile-show.html
+++ b/templates/profile-show.html
@@ -35,7 +35,7 @@
                       <div class="email__address">
                         <label><%= user.email %></label>
                         <div class="email__status">
-                          <span class="cd-tag cd-tag--rounded cd-tag--color-6">Primary</span>
+                          <span class="cd-tag cd-tag--rounded">Primary</span>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
# HID-2202

Enhancing the ongoing CD v3 work with the new CD Tag.

I had to adjust tag colors to be darker based on a11y feedback from Lighthouse. I feel like long term we should probably raise this to Javi and see if we can adjust the color scheme "from the top" instead of having to balance on-brand with accessible.

The branch also fixes some focus issues. I had to dig back through CD commit history but it seems a bunch of variables were renamed (e.g. `--cd-bright-blue` which effectively removed focus styles from the website, since the value no longer existed.