### PR TITLE
HID-2218: CSP-allowable submit handlers

### DIFF
--- a/assets/js/confirmation.js
+++ b/assets/js/confirmation.js
@@ -1,6 +1,6 @@
 /**
- * Helper function to confirm an email deletion.
+ * Helper function to confirm a removal.
  */
-function confirmDeletion (identifier) {
+function confirmRemoval (identifier) {
   return window.confirm('Are you sure you want to remove ' + identifier + ' from your profile?');
 }

--- a/assets/js/profile-edit.js
+++ b/assets/js/profile-edit.js
@@ -5,14 +5,14 @@
  * - confirmation.js
  */
 (function iife () {
-  var formEmails = document.querySelector('.form--profile-emails');
-  var formActions = document.querySelectorAll('button[name="email_delete"]');
+  var form = document.querySelector('.form--profile-emails');
+  var formActions = document.querySelectorAll('.form--profile-emails button');
   var formAction = null;
   var emailToDelete = null;
 
   // Require a confirmation before deleting an email from the profile.
   // Any other submission should drop through.
-  formEmails.addEventListener('submit', function (ev) {
+  form.addEventListener('submit', function (ev) {
     // If the user is removing an email, confirm it first.
     // Otherwise allow the form to submit like normal.
     if (formAction !== 'email_delete' || confirmRemoval(emailToDelete)) {
@@ -27,7 +27,7 @@
   // confirmation of the deletion.
   formActions.forEach(function (btn) {
     btn.addEventListener('click', function (ev) {
-      formAction = 'email_delete';
+      formAction = btn.name;
       emailToDelete = btn.value;
     });
   });

--- a/assets/js/profile-edit.js
+++ b/assets/js/profile-edit.js
@@ -1,0 +1,23 @@
+/**
+ * Profile Edit
+ *
+ * Dependencies:
+ * - confirmation.js
+ */
+(function iife () {
+  var formEmails = document.querySelector('.form--profile-emails');
+
+  // Require a confirmation before deleting an email from the profile.
+  formEmails.addEventListener('submit', function (ev) {
+    var formAction = ev.submitter.name;
+    var emailToDelete = ev.submitter.value;
+
+    // If the user is removing an email, confirm it first.
+    // Otherwise allow the form to submit like normal.
+    if (formAction !== 'email_delete' || confirmRemoval(emailToDelete)) {
+      // Allow the submission
+    } else {
+      ev.preventDefault();
+    }
+  });
+}());

--- a/assets/js/profile-edit.js
+++ b/assets/js/profile-edit.js
@@ -6,18 +6,29 @@
  */
 (function iife () {
   var formEmails = document.querySelector('.form--profile-emails');
+  var formActions = document.querySelectorAll('button[name="email_delete"]');
+  var formAction = null;
+  var emailToDelete = null;
 
   // Require a confirmation before deleting an email from the profile.
+  // Any other submission should drop through.
   formEmails.addEventListener('submit', function (ev) {
-    var formAction = ev.submitter.name;
-    var emailToDelete = ev.submitter.value;
-
     // If the user is removing an email, confirm it first.
     // Otherwise allow the form to submit like normal.
     if (formAction !== 'email_delete' || confirmRemoval(emailToDelete)) {
-      // Allow the submission
+      // Allow the submission.
     } else {
+      // Prevent the submission.
       ev.preventDefault();
     }
+  });
+
+  // When triggering the delete buttons, set up the submit handler to require
+  // confirmation of the deletion.
+  formActions.forEach(function (btn) {
+    btn.addEventListener('click', function (ev) {
+      formAction = 'email_delete';
+      emailToDelete = btn.value;
+    });
   });
 }());

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,20 +1,20 @@
 /**
- * Profile Edit
+ * Settings
  *
  * Dependencies:
  * - confirmation.js
  */
 (function iife () {
-  var form = document.querySelector('.form--profile-emails');
+  var form = document.querySelector('.form--settings-oauth-clients');
   var formActions = form.querySelectorAll('button');
   var formAction = null;
-  var emailToDelete = null;
+  var clientToRevoke = null;
 
   // Validate form submissions.
   form.addEventListener('submit', function (ev) {
     // The form allows most submissions by default.
-    // However if the user is removing an email, confirm it first.
-    if (formAction !== 'email_delete' || confirmRemoval(emailToDelete)) {
+    // However if the user is revoking an OAuth Client, confirm it first.
+    if (formAction !== 'oauth_client_revoke' || confirmRemoval(clientToRevoke)) {
       // Allow the submission.
     } else {
       // Prevent the submission.
@@ -27,7 +27,7 @@
   formActions.forEach(function (btn) {
     btn.addEventListener('click', function (ev) {
       formAction = btn.name;
-      emailToDelete = btn.value;
+      clientToRevoke = btn.dataset.clientName;
     });
   });
 }());

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 3.2.1
+  version: 3.2.2
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -8,7 +8,7 @@
       <% include alert.html %>
       <div class="profile profile--edit">
 
-        <form action="/profile/edit" method="POST" class="[ flow ]">
+        <form action="/profile/edit" method="POST" class="form--profile-basic [ flow ]">
           <div class="form-field">
             <h2>Manage basic info</h2>
             <p>You are required to provide your family name and given name.</p>
@@ -27,7 +27,7 @@
           </div>
         </form>
 
-        <form name="emailForm" action="/profile/edit/emails" method="POST" class="[ flow ]">
+        <form name="emailForm" action="/profile/edit/emails" method="POST" class="form--profile-emails [ flow ]">
           <div class="form-field [ flow ]">
             <h2>Manage email addresses</h2>
             <p>Use the radio buttons to select a new primary email address. You may only select an address which has already been confirmed.</p>
@@ -52,8 +52,7 @@
                       type="submit"
                       name="email_delete"
                       value="<%= thisEmail.email %>"
-                      class="cd-button cd-button--small cd-button--bold cd-button--uppercase cd-button--danger"
-                      onclick="return confirmDeletion('<%= thisEmail.email %>')"
+                      class="email-delete cd-button cd-button--small cd-button--bold cd-button--uppercase cd-button--danger"
                     >
                       Delete
                     </button>
@@ -84,4 +83,5 @@
 </div>
 
 <script src="/assets/js/confirmation.js"></script>
+<script src="/assets/js/profile-edit.js"></script>
 <% include footer %>

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -52,7 +52,7 @@
                       type="submit"
                       name="email_delete"
                       value="<%= thisEmail.email %>"
-                      class="email-delete cd-button cd-button--small cd-button--bold cd-button--uppercase cd-button--danger"
+                      class="cd-button cd-button--small cd-button--bold cd-button--uppercase cd-button--danger"
                     >
                       Delete
                     </button>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -25,7 +25,7 @@
 
       <section id="section-apps">
         <h2>Authorized Apps</h2>
-        <form action="/settings/oauth-clients" method="POST">
+        <form action="/settings/oauth-clients" method="POST" class="form--settings-oauth-clients">
           <% if (user.authorizedClients.length === 0) { %>
             <p><em>You haven't authorized any websites yet. After you log in with HID on one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service.html" target="_blank" rel="noopener">Partner Sites</a> you will see it listed here.</em></p>
           <% } else { %>
@@ -42,8 +42,8 @@
                     name="oauth_client_revoke"
                     value="<%= client._id.toString() %>"
                     class="cd-button cd-button--danger"
-                    onclick="return confirmDeletion('<%= client.name %>');"
                     aria-label="Revoke <%= client.name %>"
+                    data-client-name="<%= client.name %>"
                   >Revoke</button>
                 </span>
                 <span class="client__info">
@@ -71,7 +71,8 @@
   </div>
 </main>
 
-<% include footer %>
-
-<script src="/assets/js/confirmation.js"></script>
 <script src="/assets/js/tabs.js"></script>
+<script src="/assets/js/confirmation.js"></script>
+<script src="/assets/js/settings.js"></script>
+
+<% include footer %>


### PR DESCRIPTION
# HID-2218

I realized another missing piece of UX due to the CSP. The confirmation dialogs should be restored in these two situations: 

- Deleting emails from your profile. URL: `/profile/edit`
- Revoking OAuth Clients. URL: `/settings`