### PR TITLE
HID-2224: always redirect to official URLs for partner sites

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -585,8 +585,9 @@ module.exports = {
               },
             );
 
-            // extract hostname from redirect URL
-            errorRedirectUrl = new URL(redirect).origin;
+            // Extract hostname from redirect URL
+            const officialRedirect = client.redirectUri || client.redirectUrls[0];
+            errorRedirectUrl = new URL(officialRedirect).origin;
 
             throw Error(`Wrong redirect URI: ${redirect}`);
           }

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 3.3.1
+  version: 3.3.3
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-2224

Sometimes we show a redirect URL when the partner site had a configuration error. This is a templating change to prevent us from linking anywhere except an official redirect URL that we store inside HID.

## Testing

The easiest way to test this is by falsifying an OAuth Client within HID and leave your Drupal site as-is:

- If necessary, reset the password for a known admin account using the included Mailhog instance.
- Log in as admin, and go to `/admin` to see the list of Clients
- Edit the entry for your chosen OAuth Client, falsifying both the `redirect_uri` and `redirect_urls` fields.
- Try logging in with Drupal and ensure that the value displayed is from the HID DB, and NOT from the Drupal site's `redirectUri` value:

<img width="800" alt="HID-2224-gho-offical" src="https://user-images.githubusercontent.com/254753/117425842-7bc29d00-af23-11eb-94dc-8777cdb27f12.png">
