### PR TITLE
HID-2226: GA wants to load more code via data URI

### DIFF
--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -191,7 +191,7 @@ module.exports = {
       return reply.view('register', {
         alert: {
           type: 'error',
-          message: 'There was a problem validating your registration. Please try again.',
+          message: 'There was an internal server error while processing your registration. Please try again, and if the problem persists notify info@humanitarian.id',
         },
         formEmail: request.payload.email,
         formGivenName: request.payload.given_name,

--- a/config/web.js
+++ b/config/web.js
@@ -118,7 +118,7 @@ module.exports = {
           // GA allowed, plus anything it wants to cram in afterwards via data:
           'https://www.google-analytics.com',
           'data:',
-          // Google reCAPTCHA v2 scripts
+          // Google reCAPTCHA v2: scripts to load UI. See frameSrc.
           'https://www.google.com',
           'https://www.gstatic.com',
           // These hashes are for GA and our inline JS+feature detection.
@@ -133,6 +133,7 @@ module.exports = {
           'https://stage.api-humanitarian-id.ahconu.org',
         ],
         frameSrc: [
+          // Google reCAPTCHA v2: this allows the UI to be displayed
           'https://www.google.com',
         ],
         imgSrc: [

--- a/config/web.js
+++ b/config/web.js
@@ -118,6 +118,9 @@ module.exports = {
           // GA allowed, plus anything it wants to cram in afterwards via data:
           'https://www.google-analytics.com',
           'data:',
+          // Google reCAPTCHA v2 scripts
+          'https://www.google.com',
+          'https://www.gstatic.com',
           // These hashes are for GA and our inline JS+feature detection.
           "'sha256-zITkoAg4eI1v3VSFI+ATEQKWvoymQcxmFNojptzmlNw='",
           "'sha256-Ch69wX3la/uD7qfUZRHgam3hofEvI6fesgFgtvG9rTM='",
@@ -128,6 +131,9 @@ module.exports = {
           'https://stats.g.doubleclick.net',
           // API Docs connect to Stage by default
           'https://stage.api-humanitarian-id.ahconu.org',
+        ],
+        frameSrc: [
+          'https://www.google.com',
         ],
         imgSrc: [
           'self',

--- a/config/web.js
+++ b/config/web.js
@@ -115,7 +115,9 @@ module.exports = {
         ],
         scriptSrc: [
           'self',
+          // GA allowed, plus anything it wants to cram in afterwards via data:
           'https://www.google-analytics.com',
+          'data:',
           // These hashes are for GA and our inline JS+feature detection.
           "'sha256-zITkoAg4eI1v3VSFI+ATEQKWvoymQcxmFNojptzmlNw='",
           "'sha256-Ch69wX3la/uD7qfUZRHgam3hofEvI6fesgFgtvG9rTM='",

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 3.3.4
+  version: 3.3.3
   title: HID API
   license:
     name: Apache-2.0

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 3.3.1
+  version: 3.3.4
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.2",
+  "version": "3.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.4",
+  "version": "3.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.4",
+  "version": "3.3.3",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.2",
+  "version": "3.3.4",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-2226

Post-launch I noticed that in our remote environments, GA was being blocked by our new CSP on account of `data:` not being allowed. This seems to work on dev when I deployed a feature branch.

# HID-2227

We've also noticed reCAPTCHA is no longer working and that's also due to the CSP.