### PR TITLE
HID-2235: remove newrelic from our dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,8 @@ module.exports = {
     "no-plusplus": "off",
     "no-underscore-dangle": "off",
     "prefer-destructuring": "off",
+    "import/no-unresolved": [2, {
+      ignore: ['newrelic'],
+    }],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2667,37 +2667,46 @@
         }
       }
     },
-    "@ladjs/i18n": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@ladjs/i18n/-/i18n-7.1.0.tgz",
-      "integrity": "sha512-VWR2AS0I+EdMF5HOR8PvNzW/Cq1QcFVQ3zvlqY0oOdYTPrll3hIqlDwFhumMoSm/Sn7OMYaFdip3Wi6ukCrqIA==",
+    "@ladjs/country-language": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@ladjs/country-language/-/country-language-0.2.1.tgz",
+      "integrity": "sha512-e3AmT7jUnfNE6e2mx2+cPYiWdFW3McySDGRhQEYE6SksjZTMj0PTp+R9x1xG89tHRTsyMNJFl9J4HtZPWZzi1Q==",
       "requires": {
-        "@hapi/boom": "^9.1.1",
-        "boolean": "3.0.2",
-        "country-language": "^0.1.7",
+        "underscore": "~1.13.1",
+        "underscore.deep": "~0.5.1"
+      }
+    },
+    "@ladjs/i18n": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@ladjs/i18n/-/i18n-7.2.3.tgz",
+      "integrity": "sha512-bCqZH47iH9XlfjG2IknNxfovvqtfRfmZYYwnTR+8e0FSz6ZKgF/u7X3PAM/sYz/YAc/01Z3/T2bZlmbSrFtUcg==",
+      "requires": {
+        "@hapi/boom": "^9.1.2",
+        "@ladjs/country-language": "^0.2.1",
+        "boolean": "3.0.4",
         "debug": "^4.3.1",
-        "i18n": "^0.13.2",
-        "i18n-locales": "^0.0.4",
+        "i18n": "^0.13.3",
+        "i18n-locales": "^0.0.5",
         "lodash": "^4.17.21",
         "multimatch": "^5.0.0",
         "punycode": "^2.1.1",
-        "qs": "^6.9.6",
-        "titleize": "^2.1.0",
-        "tlds": "^1.218.0"
+        "qs": "^6.10.1",
+        "titleize": "2",
+        "tlds": "^1.221.1"
       },
       "dependencies": {
         "@hapi/boom": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.1.tgz",
-          "integrity": "sha512-VNR8eDbBrOxBgbkddRYIe7+8DZ+vSbV6qlmaN2x7eWjsUjy2VmQgChkOKcVZIeupEZYj+I0dqNg430OhwzagjA==",
+          "version": "9.1.2",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.2.tgz",
+          "integrity": "sha512-uJEJtiNHzKw80JpngDGBCGAmWjBtzxDCz17A9NO2zCi8LLBlb5Frpq4pXwyN+2JQMod4pKz5BALwyneCgDg89Q==",
           "requires": {
             "@hapi/hoek": "9.x.x"
           }
         },
         "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+          "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
         },
         "debug": {
           "version": "4.3.1",
@@ -2707,20 +2716,18 @@
             "ms": "2.1.2"
           }
         },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "qs": {
-          "version": "6.9.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         }
       }
     },
@@ -2830,9 +2837,9 @@
       }
     },
     "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
     },
     "@types/mongodb": {
       "version": "3.6.9",
@@ -3580,9 +3587,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "boolean": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.2.tgz",
-      "integrity": "sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.4.tgz",
+      "integrity": "sha512-5pyOr+w2LNN72F2mAq6J0ckHUfJYSgRKma7e/wlcMMhgOLV9OI0ERhERYXxUqo+dPyVxcbXKy9n+wg13+LpNnA=="
     },
     "boom": {
       "version": "7.3.0",
@@ -3752,6 +3759,15 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "callsites": {
@@ -4290,15 +4306,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "country-language": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/country-language/-/country-language-0.1.7.tgz",
-      "integrity": "sha1-eHD0uhJduaYHHxlze9nvk0OuNds=",
-      "requires": {
-        "underscore": "~1.7.0",
-        "underscore.deep": "~0.5.1"
-      }
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -5734,6 +5741,23 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        }
+      }
+    },
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -6062,9 +6086,9 @@
       "dev": true
     },
     "i18n": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.13.2.tgz",
-      "integrity": "sha512-PB65bHhQESMBIl/xVNChEAzoxZ5W6FrZ1H9Ma/YcPeSfE7VS9b0sqwBPusa0CfzSKUPSl+uMhRIgyv3jkE7XNw==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.13.3.tgz",
+      "integrity": "sha512-QDmY2joBdKxj3wvk2LKyvZkjwGHta882kYHwEvx1WbwiPAet49kEU7cxzGfnrtWrfh4+7I07kBc0ZSjSlhnKyQ==",
       "requires": {
         "debug": "^4.1.1",
         "make-plural": "^6.2.2",
@@ -6090,11 +6114,11 @@
       }
     },
     "i18n-locales": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/i18n-locales/-/i18n-locales-0.0.4.tgz",
-      "integrity": "sha512-aP6VjhoBwSC8uZUehHWSszqdeWiheNXp0+oLPcZY4QAktsqcouHNYQee2NQFM4KNcCTKHHbfXrRUuOxjxF2jYw==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/i18n-locales/-/i18n-locales-0.0.5.tgz",
+      "integrity": "sha512-Kve1AHy6rqyfJHPy8MIvaKBKhHhHPXV+a/TgMkjp3UBhO3gfWR40ZQn8Xy7LI6g3FhmbvkFtv+GCZy6yvuyeHQ==",
       "requires": {
-        "country-language": "^0.1.7"
+        "@ladjs/country-language": "^0.2.1"
       }
     },
     "iconv-lite": {
@@ -9438,9 +9462,9 @@
       }
     },
     "mustache": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.1.0.tgz",
-      "integrity": "sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -11278,6 +11302,23 @@
       "dev": true,
       "optional": true
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "dependencies": {
+        "object-inspect": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+        }
+      }
+    },
     "sift": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
@@ -11964,9 +12005,9 @@
       "integrity": "sha512-m+apkYlfiQTKLW+sI4vqUkwMEzfgEUEYSqljx1voUE3Wz/z1ZsxyzSxvH2X8uKVrOp7QkByWt0rA6+gvhCKy6g=="
     },
     "tlds": {
-      "version": "1.218.0",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.218.0.tgz",
-      "integrity": "sha512-JpD3eSrYaIFlU/OvtI5WTEK+v5qXZSeUifz4hT2bJsJKx5ykjZvg6i5yXVBJNjoN3XbTCtryc7H5v8B16yHfMg=="
+      "version": "1.221.1",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.221.1.tgz",
+      "integrity": "sha512-N1Afn/SLeOQRpxMwHBuNFJ3GvGrdtY4XPXKPFcx8he0U9Jg9ZkvTKE1k3jQDtCmlFn44UxjVtouF6PT4rEGd3Q=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -12168,9 +12209,9 @@
       }
     },
     "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "underscore.deep": {
       "version": "0.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2724,40 +2724,6 @@
         }
       }
     },
-    "@newrelic/koa": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.8.tgz",
-      "integrity": "sha512-kY//FlLQkGdUIKEeGJlyY3dJRU63EG77YIa48ACMGZxQbWRd3WZMikyft33f8XScTq6WpCDo9xa0viNo8zeYkg==",
-      "requires": {
-        "methods": "^1.1.2"
-      }
-    },
-    "@newrelic/native-metrics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-4.1.0.tgz",
-      "integrity": "sha512-7CZlKMLuaYQW7mV9qVyo9b9HVe2xBnyn+kkETRJoZGs5P7gdfv9AAE3RPhtOBUopTfbmc8ju7njYadjui9J1XA==",
-      "optional": true,
-      "requires": {
-        "nan": "^2.12.1",
-        "semver": "^5.5.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "optional": true
-        }
-      }
-    },
-    "@newrelic/superagent": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-1.0.3.tgz",
-      "integrity": "sha512-lJbsqKa79qPLbHZsbiRaXl1jfzaXAN7zqqnLRqBY+zI/O5zcfyNngTmdi+9y+qIUq7xHYNaLsAxCXerrsoINKg==",
-      "requires": {
-        "methods": "^1.1.2"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
@@ -2925,11 +2891,6 @@
         "@types/node": "*"
       }
     },
-    "@tyriar/fibonacci-heap": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz",
-      "integrity": "sha512-bYuSNomfn4hu2tPiDN+JZtnzCpSpbJ/PNeulmocDy3xN2X5OkJL65zo6rPZp65cPPhLF9vfT/dgE+RtFRCSxOA=="
-    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -2986,14 +2947,6 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
-    },
-    "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-      "requires": {
-        "es6-promisify": "^5.0.0"
-      }
     },
     "ajv": {
       "version": "6.10.2",
@@ -3781,7 +3734,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
@@ -4217,17 +4171,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "configstore": {
       "version": "3.1.2",
@@ -4854,19 +4797,6 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
-      }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
       }
     },
     "escalade": {
@@ -6123,15 +6053,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-      "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
       }
     },
     "human-signals": {
@@ -9256,11 +9177,6 @@
       "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
       "integrity": "sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg=="
     },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
     "micromatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -9532,12 +9448,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "optional": true
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -9562,30 +9472,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "newrelic": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-5.11.0.tgz",
-      "integrity": "sha512-KGWYdQkCIovYW8rtKE1aVu7Sl44xEGHtqXsSuInVWJJyfbI9KN0ZjnZUzdUA7SHlMM6XrW+TPY0bphSjUV2kWw==",
-      "requires": {
-        "@newrelic/koa": "^1.0.8",
-        "@newrelic/native-metrics": "^4.0.0",
-        "@newrelic/superagent": "^1.0.2",
-        "@tyriar/fibonacci-heap": "^2.0.7",
-        "async": "^2.1.4",
-        "concat-stream": "^2.0.0",
-        "https-proxy-agent": "^2.2.1",
-        "json-stringify-safe": "^5.0.0",
-        "readable-stream": "^3.1.1",
-        "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
     },
     "nice-try": {
       "version": "1.0.5",
@@ -12231,11 +12117,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "moment": "^2.24.0",
     "mongoose": "^5.12.0",
     "mongoose-validator": "^1.3.2",
-    "newrelic": "^5.11.0",
     "node-fetch": ">=2.6.1",
     "nodemailer": "^6.4.16",
     "oauth2orize": "UN-OCHA/oauth2orize",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 /**
  * @module server
  */
+
 const newrelic = require('newrelic');
 const path = require('path');
 const _ = require('lodash');


### PR DESCRIPTION
# HID-2235

We're removing NewRelic from our dependencies because it is baked into the node.js image, as discussed in OPS-7464