### PR TITLE
HID-2233: ranomize new  OAuth Client IDs

### DIFF
--- a/commands/createOAuthClient.js
+++ b/commands/createOAuthClient.js
@@ -17,15 +17,18 @@ mongoose.connect(store.uri, store.options);
 const Client = require('../api/models/Client');
 
 // Generate a random secret each time we run the command
-const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()';
+const id_chars = 'abcdefghijklmnopqrstuvwxyz';
+const secret_chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()';
+let suffix = '';
 let secret = '';
 for (let i = 0; i < 36; i++) {
-  secret += chars.charAt(Math.floor(Math.random() * chars.length));
+  suffix += id_chars.charAt(Math.floor(Math.random() * id_chars.length));
+  secret += secret_chars.charAt(Math.floor(Math.random() * secret_chars.length));
 }
 
 async function run() {
   const clientInfo = {
-    id: 'change-me',
+    id: 'change-me-' + suffix.substring(0, 6),
     name: 'CHANGE ME',
     secret,
     url: 'https://example.com/',

--- a/commands/createOAuthClient.js
+++ b/commands/createOAuthClient.js
@@ -17,18 +17,18 @@ mongoose.connect(store.uri, store.options);
 const Client = require('../api/models/Client');
 
 // Generate a random secret each time we run the command
-const id_chars = 'abcdefghijklmnopqrstuvwxyz';
-const secret_chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()';
+const idChars = 'abcdefghijklmnopqrstuvwxyz';
+const secretChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()';
 let suffix = '';
 let secret = '';
 for (let i = 0; i < 36; i++) {
-  suffix += id_chars.charAt(Math.floor(Math.random() * id_chars.length));
-  secret += secret_chars.charAt(Math.floor(Math.random() * secret_chars.length));
+  suffix += idChars.charAt(Math.floor(Math.random() * idChars.length));
+  secret += secretChars.charAt(Math.floor(Math.random() * secretChars.length));
 }
 
 async function run() {
   const clientInfo = {
-    id: 'change-me-' + suffix.substring(0, 6),
+    id: `change-me-${suffix.substring(0, 6)}`,
     name: 'CHANGE ME',
     secret,
     url: 'https://example.com/',

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 3.3.7
+  version: 3.3.9
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-2233

Preventing a rare potential error before it bites us. Randomizes the `client_id` of a new OAuth Client since we generate them via Jenkins. Now you can run the job multiple times (say you want dev/stage/live) and it is quite unlikely to create collisions.

## Testing

Run this command inside the `api` container a couple times in a row:

```sh
docker-compose exec api node commands/createOAuthClient.js
```

Old behavior would have had errors on the second time and afterwards. PR should be able to run it essentially unlimited number of times. 308,915,776 times to be exact.