### PR TITLE
HID-2228: set cursor:pointer on all CD Buttons

### DIFF
--- a/assets/css/cd-button.css
+++ b/assets/css/cd-button.css
@@ -51,6 +51,7 @@
     color 0.6s ease-out;
   text-align: center;
   color: var(--cd-white);
+  cursor: pointer;
   border: 2px solid transparent;
   border-radius: 3px;
   background-color: var(--cd-primary-color);

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 3.3.9
+  version: 3.3.10
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-2228

Temporarily applies `cursor: pointer;` to CD Buttons. Upstream PR to fold this into CD: https://github.com/UN-OCHA/common_design/pull/244