### PR TITLE
HID-1997: account.json error

### DIFF
--- a/_tests/e2e/_env/example.js
+++ b/_tests/e2e/_env/example.js
@@ -1,10 +1,6 @@
 module.exports = {
   baseUrl: 'http://hid.test',
 
-  // Test params
-  timeoutLong: 15000,
-  timeoutLonger: 30000,
-
   // Users/data
   testUserId: '',
   testUserNameGiven: 'Test',

--- a/api/policies/AuthPolicy.js
+++ b/api/policies/AuthPolicy.js
@@ -119,19 +119,15 @@ module.exports = {
    * Does the user have an HID account?
    */
   isUser(request) {
-    // First, check if credentials were sent at all. If not, we can instruct the
-    // user to authenticate before trying again by sending 401.
-    if (!request.auth.credentials) {
-      throw Boom.unauthorized();
-    }
-
     // User authenticated correctly, and has a user ID.
-    if (request.auth.credentials.id) {
+    if (request && request.auth && request.auth.credentials && request.auth.credentials.id) {
       return true;
     }
 
-    // If something else happens that we didn't predict, send HTTP 401.
-    throw Boom.unauthorized();
+    // Request lacked the proper Authorization header. If the header was sent
+    // with an invalid token, the 401 will get thrown before this function ever
+    // executes, and it will return a response saying the token was invalid.
+    throw Boom.unauthorized('Send an Authorization header with the Bearer token of the user account you wish to load. For more info see: https://github.com/UN-OCHA/hid_api/wiki/Integrating-with-HID-via-OAuth#step-3--request-user-account-info');
   },
 
   /**

--- a/api/policies/AuthPolicy.js
+++ b/api/policies/AuthPolicy.js
@@ -115,6 +115,28 @@ module.exports = {
     return true;
   },
 
+  /**
+   * Does the user have an HID account?
+   */
+  isUser(request) {
+    // First, check if credentials were sent at all. If not, we can instruct the
+    // user to authenticate before trying again by sending 401.
+    if (!request.auth.credentials) {
+      throw Boom.unauthorized();
+    }
+
+    // User authenticated correctly, and has a user ID.
+    if (request.auth.credentials.id) {
+      return true;
+    }
+
+    // If something else happens that we didn't predict, send HTTP 401.
+    throw Boom.unauthorized();
+  },
+
+  /**
+   * Is the user an admin?
+   */
   isAdmin(request) {
     // First, check if credentials were sent at all. If not, we can instruct the
     // user to authenticate before trying again by sending 401.

--- a/api/policies/AuthPolicy.js
+++ b/api/policies/AuthPolicy.js
@@ -1,82 +1,84 @@
+/**
+* @module AuthPolicy
+* @description a collection of functions to enforce authentication and user
+* permissions for HID.
+*/
 const Boom = require('@hapi/boom');
 const authenticator = require('authenticator');
 const config = require('../../config/env');
 
 const { logger } = config;
 
-/**
-* @module AuthPolicy
-* @description Is the request authenticated
-*/
-
-async function isTOTPValid(user, token) {
-  if (!user.totpConf || !user.totpConf.secret) {
-    logger.warn(
-      `[AuthPolicy->isTOTPValid] TOTP was not configured for user ${user.id}`,
-      { security: true },
-    );
-    throw Boom.unauthorized('TOTP was not configured for this user', 'totp');
-  }
-
-  if (!token) {
-    logger.warn(
-      '[AuthPolicy->isTOTPValid] No TOTP token',
-      { security: true },
-    );
-    throw Boom.unauthorized('No TOTP token', 'totp');
-  }
-
-  if (token.length === 6) {
-    const success = authenticator.verifyToken(user.totpConf.secret, token);
-
-    if (success) {
-      return user;
-    }
-    logger.warn(
-      `[AuthPolicy->isTOTPValid] Invalid TOTP token ${token}`,
-      {
-        security: true,
-        fail: true,
-      },
-    );
-    throw Boom.unauthorized('Invalid TOTP token !', 'totp');
-  }
-
-  // Using backup code
-  const index = user.backupCodeIndex(token);
-  if (index === -1) {
-    logger.warn(
-      `[AuthPolicy->isTOTPValid] Invalid backup code ${token}`,
-      {
-        security: true,
-        fail: true,
-      },
-    );
-    throw Boom.unauthorized('Invalid backup code !', 'totp');
-  }
-
-  // Remove backup code so it can't be reused.
-  user.totpConf.backupCodes.splice(index, 1);
-  user.markModified('totpConf.backupCodes');
-  await user.save();
-
-  logger.info(
-    `[AuthPolicy->isTOTPValid] Successfully removed a backup code for user ${user.id}`,
-    {
-      security: true,
-      user: {
-        id: user.id,
-        email: user.email,
-      },
-    },
-  );
-
-  return user;
-}
-
 module.exports = {
+  /**
+   * Enforces a _mandatory_ 2FA code requirement. If the user doesn't have 2FA
+   * enabled, then this function will unconditionally return false. User can
+   * supply either TOTPs or backup codes.
+   */
+  async isTOTPValid(user, token) {
+    if (!user.totpConf || !user.totpConf.secret) {
+      logger.warn(
+        `[AuthPolicy->isTOTPValid] TOTP was not configured for user ${user.id}`,
+        { security: true },
+      );
+      throw Boom.unauthorized('TOTP was not configured for this user', 'totp');
+    }
 
-  isTOTPValid,
+    if (!token) {
+      logger.warn(
+        '[AuthPolicy->isTOTPValid] No TOTP token',
+        { security: true },
+      );
+      throw Boom.unauthorized('No TOTP token', 'totp');
+    }
+
+    if (token.length === 6) {
+      const success = authenticator.verifyToken(user.totpConf.secret, token);
+
+      if (success) {
+        return user;
+      }
+      logger.warn(
+        `[AuthPolicy->isTOTPValid] Invalid TOTP token ${token}`,
+        {
+          security: true,
+          fail: true,
+        },
+      );
+      throw Boom.unauthorized('Invalid TOTP token !', 'totp');
+    }
+
+    // Using backup code
+    const index = user.backupCodeIndex(token);
+    if (index === -1) {
+      logger.warn(
+        `[AuthPolicy->isTOTPValid] Invalid backup code ${token}`,
+        {
+          security: true,
+          fail: true,
+        },
+      );
+      throw Boom.unauthorized('Invalid backup code !', 'totp');
+    }
+
+    // Remove backup code so it can't be reused.
+    user.totpConf.backupCodes.splice(index, 1);
+    user.markModified('totpConf.backupCodes');
+    await user.save();
+
+    logger.info(
+      `[AuthPolicy->isTOTPValid] Successfully removed a backup code for user ${user.id}`,
+      {
+        security: true,
+        user: {
+          id: user.id,
+          email: user.email,
+        },
+      },
+    );
+
+    return user;
+  },
 
   /**
    * Enforces an _optional_ TOTP requirement. If the user has 2FA enabled, they
@@ -100,7 +102,7 @@ module.exports = {
     }
 
     // Validate the TOTP code.
-    await isTOTPValid(user, totp);
+    await this.isTOTPValid(user, totp);
 
     // If no error was thrown, return true.
     return true;
@@ -109,7 +111,7 @@ module.exports = {
   async isTOTPValidPolicy(request) {
     const user = request.auth.credentials;
     const token = request.headers['x-hid-totp'];
-    await isTOTPValid(user, token);
+    await this.isTOTPValid(user, token);
     return true;
   },
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -327,7 +327,12 @@ module.exports = [
   {
     method: ['GET', 'POST'],
     path: '/account.json',
-    handler: AuthController.showAccount,
+    options: {
+      pre: [
+        AuthPolicy.isUser,
+      ],
+      handler: AuthController.showAccount,
+    },
   },
 
   {

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 3.3.9
+  version: 3.3.11
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.9",
+  "version": "3.3.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.9",
+  "version": "3.3.11",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# HID-1997

We used to serve HTTP 200 with an empty object `{}` when the Authorization header was missing or invalid. Then at some point the API started serving HTTP 500, I would guess when we changed the payload that gets sent for v3.

This PR brings us in line with the [official OpenID Connect spec](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoError) by returning HTTP 401 for both missing and invalid tokens. I also updated the [appropriate wiki section](https://github.com/UN-OCHA/hid_api/wiki/Integrating-with-HID-via-OAuth#step-3--request-user-account-info) with an example.

## Testing

Visiting `/account.json` in your browser should now produce HTTP 401 instead of 200 or 500. Sending the Authorization header, or logging in with Drupal should (naturally) produce the user account.

The other stuff that got shuffled around is related to 2FA, and there are no actual changes, only moving code within the file. Testing something like a password reset on a 2FA user is sufficient to ensure it's working. 