### PR TITLE
HID-2248: better errors and logging for password resets

### DIFF
--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -361,7 +361,10 @@ module.exports = {
   async newPassword(request, reply) {
     request.yar.reset();
     request.yar.set('session', {
-      hash: request.query.hash, id: request.query.id, time: request.query.time, totp: false,
+      hash: request.query.hash,
+      id: request.query.id,
+      time: request.query.time,
+      totp: false,
     });
 
     const user = await User.findOne({ _id: request.query.id });
@@ -379,7 +382,10 @@ module.exports = {
     }
 
     request.yar.set('session', {
-      hash: request.query.hash, id: request.query.id, time: request.query.time, totp: true,
+      hash: request.query.hash,
+      id: request.query.id,
+      time: request.query.time,
+      totp: true,
     });
 
     return reply.view('new_password', {
@@ -397,9 +403,11 @@ module.exports = {
       try {
         const user = await User.findOne({ _id: cookie.id });
         const token = request.payload['x-hid-totp'];
+
         await AuthPolicy.isTOTPValid(user, token);
         cookie.totp = true;
         request.yar.set('session', cookie);
+
         return reply.view('new_password', {
           query: request.payload,
           hash: cookie.hash,
@@ -423,8 +431,10 @@ module.exports = {
       const params = HelperService.getOauthParams(request.payload);
       const registerLink = _getRegisterLink(request.payload);
       const passwordLink = _getPasswordLink(request.payload);
+
       try {
         await UserController.resetPasswordEndpoint(request);
+
         if (params) {
           return reply.view('login', {
             alert: {
@@ -436,6 +446,7 @@ module.exports = {
             passwordLink,
           });
         }
+
         return reply.view('message', {
           alert: {
             type: 'status',
@@ -471,7 +482,10 @@ module.exports = {
     }
 
     return reply.view('message', {
-      alert: { type: 'error', message: 'There was an error resetting your password.' },
+      alert: {
+        type: 'error',
+        message: 'There was an error resetting your password.',
+      },
       query: request.payload,
       isSuccess: false,
       title: 'Password update',

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -457,6 +457,16 @@ module.exports = {
           title: 'Password update',
         });
       } catch (err) {
+        logger.error(
+          `[ViewController->newPasswordPost] ${err.message}`,
+          {
+            request,
+            security: true,
+            fail: true,
+            stack_trace: err.stack,
+          },
+        );
+
         if (params) {
           return reply.view('login', {
             alert: {

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -370,7 +370,12 @@ module.exports = {
     const user = await User.findOne({ _id: request.query.id });
 
     if (!user) {
-      return reply.view('error');
+      return reply.view('error', {
+        alert: {
+          type: 'error',
+          message: 'The password reset link is malformed. <a href="/password">Request a new password reset link</a>.',
+        },
+      });
     }
 
     if (user.totp) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",

--- a/templates/error.html
+++ b/templates/error.html
@@ -4,7 +4,11 @@
   <div class="cd-layout-content">
     <div class="[ flow ]">
       <h1 class="cd-page-title page-header__heading">Error</h1>
-      <p>Sorry, there was an internal server error.</p>
+      <% if (typeof alert !== 'undefined') { %>
+        <% include alert.html %>
+      <% } else { %>
+        <p>There was an internal server error.</p>
+      <% } %>
     </div>
   </div>
 </main>


### PR DESCRIPTION
# HID-2248

We got a report that someone saw what looks like a 500 error during password reset. It's just uninformative, and on top of that we weren't logging anything when there was a real error.

E2E passed on my local. To test you can do two things:

- Visit http://auth.hid.test/new_password - should show a red error with a link to reset your password
- Successfully reset your password after clicking the link. Mailhog is at http://localhost:8025