### PR TITLE
HID-2250

### DIFF
--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -176,6 +176,8 @@ module.exports = {
     const passwordLink = _getPasswordLink(request.payload);
     let requestUrl = _buildRequestUrl(request, 'verify2');
 
+    // Validate the visitor's response to reCAPTCHA challenge, to ensure they
+    // are a human.
     try {
       await recaptcha.validate(request.payload['g-recaptcha-response']);
     } catch (err) {
@@ -185,6 +187,7 @@ module.exports = {
           request,
           security: true,
           fail: true,
+          stack_trace: err.stack,
         },
       );
 
@@ -203,6 +206,8 @@ module.exports = {
         recaptcha_site_key: process.env.RECAPTCHA_PUBLIC_KEY,
       });
     }
+
+    // reCAPTCHA validation was successful. Proceed.
     try {
       // Attempt to create a new HID account.
       await UserController.create(request);

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -181,6 +181,8 @@ module.exports = {
     try {
       await recaptcha.validate(request.payload['g-recaptcha-response']);
     } catch (err) {
+      const errorCode = 'RC-1';
+
       logger.warn(
         '[ViewController->registerPost] Failure during reCAPTCHA validation.',
         {
@@ -188,13 +190,18 @@ module.exports = {
           security: true,
           fail: true,
           stack_trace: err.stack,
+          error_code: errorCode,
         },
       );
 
       return reply.view('register', {
         alert: {
           type: 'error',
-          message: 'There was an internal server error while processing your registration. Please try again, and if the problem persists notify info@humanitarian.id',
+          message: `
+            <p>Bot detection registered your attempt as spam.</p>
+            <p>Please try again, and if the problem persists notify info@humanitarian.id</p>
+          `,
+          error_code: errorCode,
         },
         formEmail: request.payload.email,
         formGivenName: request.payload.given_name,

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -181,7 +181,7 @@ module.exports = {
     try {
       await recaptcha.validate(request.payload['g-recaptcha-response']);
     } catch (err) {
-      const errorCode = 'RC-1';
+      const errorCode = 'RECAPTCHA';
 
       logger.warn(
         '[ViewController->registerPost] Failure during reCAPTCHA validation.',
@@ -199,7 +199,7 @@ module.exports = {
           type: 'error',
           message: `
             <p>Bot detection registered your attempt as spam.</p>
-            <p>Please try again, and if the problem persists notify info@humanitarian.id</p>
+            <p>Please try again, and if the problem persists notify info@humanitarian.id with this error code:</p>
           `,
           error_code: errorCode,
         },

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -176,12 +176,11 @@ module.exports = {
     const passwordLink = _getPasswordLink(request.payload);
     let requestUrl = _buildRequestUrl(request, 'verify2');
 
-    // Validate the visitor's response to reCAPTCHA challenge, to ensure they
-    // are a human.
+    // Validate the visitor's response to reCAPTCHA challenge.
     try {
       await recaptcha.validate(request.payload['g-recaptcha-response']);
     } catch (err) {
-      const errorCode = 'RECAPTCHA';
+      const errorType = 'RECAPTCHA';
 
       logger.warn(
         '[ViewController->registerPost] Failure during reCAPTCHA validation.',
@@ -190,7 +189,7 @@ module.exports = {
           security: true,
           fail: true,
           stack_trace: err.stack,
-          error_code: errorCode,
+          error_type: errorType,
         },
       );
 
@@ -198,10 +197,10 @@ module.exports = {
         alert: {
           type: 'error',
           message: `
-            <p>Bot detection registered your attempt as spam.</p>
-            <p>Please try again, and if the problem persists notify info@humanitarian.id with this error code:</p>
+            <p>Our system detected your registration attempt as spam. We apologize for the inconvenience.</p>
+            <p>Please try registering again. If the problem persists notify info@humanitarian.id and include the following information:</p>
           `,
-          error_code: errorCode,
+          error_type: errorType,
         },
         formEmail: request.payload.email,
         formGivenName: request.payload.given_name,

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 3.3.11
+  version: 3.3.13
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",

--- a/templates/alert.html
+++ b/templates/alert.html
@@ -34,6 +34,9 @@
       <% } %>
         <div class="cd-alert__message">
           <%- alert.message %>
+          <% if (typeof alert.error_code !== 'undefined') { %>
+            <p>Error code: <%- alert.error_code %>_<%- Date.now() %></p>
+          <% } %>
         </div>
       </div>
     </div>

--- a/templates/alert.html
+++ b/templates/alert.html
@@ -34,8 +34,9 @@
       <% } %>
         <div class="cd-alert__message">
           <%- alert.message %>
-          <% if (typeof alert.error_code !== 'undefined') { %>
-            <p>Error code: <%- alert.error_code %>_<%- Date.now() %></p>
+          <% if (typeof alert.error_type !== 'undefined') { %>
+            <p>Error type: <%- alert.error_type %></p>
+            <p>Timestamp: <%- Date.now() %></p>
           <% } %>
         </div>
       </div>


### PR DESCRIPTION
# HID-2250

Making an error message more clear, plus logging. I also added the ability to output an "Error type" within an error message, to help the Content Squad field support requests. On any error (or any message at all) you can now include a `error_type` property, and it will manually format the string, plus output a timestamp from the server. Combined with wording on the error message, we'll be able to provide Content Squad (and our own log spelunking) better data to go hunt down problems:

<img width="942" alt="HID-2250-error-code-5" src="https://user-images.githubusercontent.com/254753/129316544-7e8e1263-831c-49cd-b919-0ab72f398d9e.png">

## Testing

Try to register a new account (even though reCAPTCHA is incorrectly configured). It should show this message.
