### PR TITLE
HID-2249: immediately fail on invalid/expired password links

### DIFF
--- a/_tests/e2e/PasswordReset.test.js
+++ b/_tests/e2e/PasswordReset.test.js
@@ -87,4 +87,22 @@ describe('PasswordReset [no-ci]', () => {
     await page.waitForTimeout(2000);
     expect(await page.content()).toContain('Thank you for updating your password.');
   });
+
+  it('immediately shows an error when password reset link is invalid', async () => {
+    // Mailhog is here when you set up via hid-stack
+    await page.goto('http://localhost:8025');
+    // We always want the first message in Mailhog. In this case we're using the
+    // SAME link as in the test above. It should now show an error if the
+    // password reset was successful.
+    await page.click('.messages > *:first-child');
+    // Target this message's iframe in Mailhog.
+    const message = await page.frames()[1];
+    // Mailhog has iframes and the link has target="_blank" and all of that makes
+    // it a real PITA to truly click the link and follow it. Let's instead grab
+    // the URL and go directly to it:
+    const pwResetUrl = await message.$eval('p:nth-child(3) a', el => el.innerText);
+    await page.goto(pwResetUrl);
+    // Do we see the password reset error?
+    expect(await page.content()).toContain('Your password reset link is either invalid or expired.');
+  });
 });

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1498,21 +1498,21 @@ module.exports = {
       record = await AuthPolicy.isTOTPValid(record, token);
     }
 
-    // Verify that password is strong enough.
-    if (!User.isStrongPassword(request.payload.password)) {
-      logger.warn(
-        '[UserController->resetPassword] Could not reset password. New password is not strong enough',
-        {
-          request,
-          security: true,
-          fail: true,
-        },
-      );
-      throw Boom.badRequest('New password is not strong enough');
-    }
-
     // Check that the reset hash was correct when the user landed on the page.
     if (record.validHash(request.payload.hash, 'reset_password', request.payload.time) === true) {
+      // Verify that password is strong enough.
+      if (!User.isStrongPassword(request.payload.password)) {
+        logger.warn(
+          '[UserController->resetPassword] Could not reset password. New password is not strong enough',
+          {
+            request,
+            security: true,
+            fail: true,
+          },
+        );
+        throw Boom.badRequest('New password is not strong enough');
+      }
+
       // Check the new password against the old one.
       if (record.validPassword(request.payload.password)) {
         logger.warn(

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1512,9 +1512,6 @@ module.exports = {
     }
 
     // Check that the reset hash was correct when the user landed on the page.
-    //
-    // TODO: HID-2249 - copy this validation to initial page load so user can
-    //       try again without wasting time. It should be kept here too.
     if (record.validHash(request.payload.hash, 'reset_password', request.payload.time) === true) {
       // Check the new password against the old one.
       if (record.validPassword(request.payload.password)) {

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1401,17 +1401,17 @@ module.exports = {
    * @api [post] /user/password
    * tags:
    *   - user
-   * summary: Resets a user password or sends a password reset email.
+   * summary: Resets a user password.
    * parameters:
    *   - name: X-HID-TOTP
    *     in: header
-   *     description: The TOTP token. Required if the user has 2FA enabled.
+   *     description: Required if the user has 2FA enabled.
    *     required: false
    *     type: string
    * requestBody:
    *   description: >-
    *     Use a password reset link.For password complexity requirements see
-   *     `PUT /user/{id}/password`
+   *     `POST /user/{id}/password`
    *   required: true
    *   content:
    *     application/json:

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -400,6 +400,21 @@ module.exports = {
       });
     }
 
+    // Before continuing, check that password link is valid. No sense in making
+    // the user do anthing if the link expired.
+    if (user.validHash(request.query.hash, 'reset_password', request.query.time) === false) {
+      return reply.view('error', {
+        alert: {
+          type: 'error',
+          title: 'Your password reset link is either invalid or expired.',
+          message: `
+            <p>Please <a href="/password">generate a new link</a> and try again. If you see this error multiple times, contact <a href="mailto:info@humanitarian.id">info@humanitarian.id</a> and include the following information:</p>
+          `,
+          error_type: 'PW-RESET-LINK',
+        },
+      });
+    }
+
     // If the user has 2FA enabled, we need them to enter a TOTP before allowing
     // them to continue.
     if (user.totp) {

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -425,19 +425,25 @@ UserSchema.methods = {
   // Validate the hash of a confirmation link
   validHash(hashLink, type, time, email) {
     if (type === 'reset_password') {
+      // Confirm that 24 hours haven't passed.
       const now = Date.now();
       if (now - time > 24 * 3600 * 1000) {
         return false;
       }
+
+      // Create and compare hash
       const value = `${time}:${this._id.toString()}:${this.password}`;
       const hash = crypto.createHmac('sha256', process.env.COOKIE_PASSWORD).update(value).digest('hex');
       return hash === hashLink;
     }
     if (type === 'verify_email') {
+      // Confirm that 24 hours haven't passed.
       const now = Date.now();
       if (now - time > 24 * 3600 * 1000) {
         return false;
       }
+
+      // Create and compare hash
       const value = `${time}:${this._id.toString()}:${email}`;
       const hash = crypto.createHmac('sha256', process.env.COOKIE_PASSWORD).update(value).digest('hex');
       return hash === hashLink;

--- a/config/routes.js
+++ b/config/routes.js
@@ -413,9 +413,17 @@ module.exports = [
   },
 
   {
-    method: 'PUT',
+    method: 'POST',
+    path: '/api/v3/user/password-email',
+    handler: UserController.resetPasswordEmail,
+    options: {
+      auth: false,
+    },
+  },
+  {
+    method: 'POST',
     path: '/api/v3/user/password',
-    handler: UserController.resetPasswordEndpoint,
+    handler: UserController.resetPassword,
     options: {
       auth: false,
     },

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 3.3.11
+  version: 4.0.0
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.12",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.12",
+  "version": "4.0.0",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",

--- a/templates/error.html
+++ b/templates/error.html
@@ -3,7 +3,12 @@
 <main role="main" id="main-content" class="cd-container">
   <div class="cd-layout-content">
     <div class="[ flow ]">
-      <h1 class="cd-page-title page-header__heading">Error</h1>
+      <% if (typeof alert !== 'undefined' && alert.title) { %>
+        <h1 class="cd-page-title page-header__heading"><%- alert.title %></h1>
+      <% } else { %>
+        <h1 class="cd-page-title page-header__heading">Error</h1>
+      <% } %>
+
       <% if (typeof alert !== 'undefined') { %>
         <% include alert.html %>
       <% } else { %>

--- a/templates/password.html
+++ b/templates/password.html
@@ -17,7 +17,7 @@
             <input type="email" name="email" id="email" placeholder="Your email address" required>
           </div>
           <input type="hidden" name="crumb" value="<%= crumb %>" />
-          <input type="hidden" name="app_reset_url" value="<%= requestUrl %>" />
+          <input type="hidden" name="reset_url" value="<%= requestUrl %>" />
           <button type="submit" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase t-btn--reset">Reset Password</button>
         </form>
       </div>


### PR DESCRIPTION
# HID-2067

Remember when we discussed changing these endpoints way back when? I finally did it. This PR eliminates the following endpoint:

- `PUT /api/v3/user/password`

And in its place we have two new ones:

- `POST /api/v3/user/password-email`
- `POST /api/v3/user/password`

Internally I also split the functions that handle these, and bumped the major version to reflect that change.

# HID-2249

With all of that cleanup done, I also provided some UX improvements to the Auth website. It will immediately fail on invalid password links. It used to let you try to reset, only informing you afterwards that the link was invalid. 2FA people also had to submit a code, filling out two forms before finding out the bad news.

Now it fails instantly and points you to the form where you can start over.

<del>There are a couple references to "the following information" which doesn't appear. That's because of a new feature inside #277 which can print an optional error code (we're going to start logging these, and it also gives Content Squad a quicker start on debugging the nature of the error).</del> _Edit:_ those will work since the other PR was merged.

There are some other bug fixes in here too. While debugging password reset URLs, I found ways to display the JSON-only 500s when sending malformed User IDs, for example. Those errors are now caught and dealt with gracefully.

## Testing

Both API and the Auth website should be tested. My local E2E (which includes a new test!) was passing when I created the PR, but I would appreciate some manual QA that I didn't forget anything.