### PR TITLE
HID-2064: split email confirmation into two routes

### DIFF
--- a/_tests/e2e/Login.test.js
+++ b/_tests/e2e/Login.test.js
@@ -1,4 +1,5 @@
 import env from './_env';
+import utils from './_utils';
 
 describe('Login', () => {
   let page;
@@ -35,15 +36,7 @@ describe('Login', () => {
   });
 
   it('allows user to log in when credentials are valid', async () => {
-    const email = await page.$('#email');
-    await email.click({ clickCount: 3 });
-    await email.type(env.testUserEmail);
-
-    const password = await page.$('#password');
-    await password.click({ clickCount: 3 });
-    await password.type(env.testUserPassword);
-
-    await page.click('.t-btn--login');
+    await utils.login(page);
     await page.waitForSelector('.t-page--dashboard');
 
     expect(await page.url()).toContain('/user');

--- a/_tests/e2e/PasswordReset.test.js
+++ b/_tests/e2e/PasswordReset.test.js
@@ -1,4 +1,5 @@
 import env from './_env';
+import utils from './_utils';
 
 describe('PasswordReset [no-ci]', () => {
   let page;
@@ -41,12 +42,8 @@ describe('PasswordReset [no-ci]', () => {
   });
 
   it('allows user to initiate password reset via email', async () => {
-    // Mailhog is here when you set up via hid-stack
-    await page.goto('http://localhost:8025');
-    // We always want the first message in Mailhog.
-    await page.click('.messages > *:first-child');
-    // Target this message's iframe in Mailhog.
-    const message = await page.frames()[1];
+    const message = await utils.openMailhogMessage(page, 1);
+
     // Mailhog has iframes and the link has target="_blank" and all of that makes
     // it a real PITA to truly click the link and follow it. Let's instead grab
     // the URL and go directly to it:
@@ -89,14 +86,10 @@ describe('PasswordReset [no-ci]', () => {
   });
 
   it('immediately shows an error when password reset link is invalid', async () => {
-    // Mailhog is here when you set up via hid-stack
-    await page.goto('http://localhost:8025');
-    // We always want the first message in Mailhog. In this case we're using the
-    // SAME link as in the test above. It should now show an error if the
-    // password reset was successful.
-    await page.click('.messages > *:first-child');
-    // Target this message's iframe in Mailhog.
-    const message = await page.frames()[1];
+    // In this case we want the SAME link as the firs time, to verify that it
+    // can't be reused.
+    const message = await utils.openMailhogMessage(page);
+
     // Mailhog has iframes and the link has target="_blank" and all of that makes
     // it a real PITA to truly click the link and follow it. Let's instead grab
     // the URL and go directly to it:
@@ -104,5 +97,9 @@ describe('PasswordReset [no-ci]', () => {
     await page.goto(pwResetUrl);
     // Do we see the password reset error?
     expect(await page.content()).toContain('Your password reset link is either invalid or expired.');
+  });
+
+  it('successfully cleaned up Mailhog', async () => {
+    await utils.clearMailhog(page, expect);
   });
 });

--- a/_tests/e2e/ProfileEmails.test.js
+++ b/_tests/e2e/ProfileEmails.test.js
@@ -1,0 +1,69 @@
+import env from './_env';
+import utils from './_utils';
+
+describe('ProfileEmails', () => {
+  let page;
+
+  beforeAll(async () => {
+    page = await context.newPage();
+    await page.goto(env.baseUrl);
+  });
+
+  it('shows user dashboard after logging in', async () => {
+    await utils.login(page);
+    await page.waitForSelector('.t-page--dashboard');
+
+    expect(await page.url()).toContain('/user');
+    expect(await page.content()).toContain(env.testUserNameGiven);
+    expect(await page.content()).toContain(env.testUserNameFamily);
+  });
+
+  it('shows user profile after clicking dashboard button', async () => {
+    await page.click('.t-btn-profile');
+    await page.waitForSelector('.t-page--profile-show');
+
+    expect(await page.url()).toContain('/profile');
+    expect(await page.content()).toContain(env.testUserNameGiven);
+    expect(await page.content()).toContain('Basic profile info');
+  });
+
+  it('allows user to edit profile', async () => {
+    await page.click('.t-btn-profile-edit');
+    await page.waitForSelector('.t-page--profile-edit');
+
+    expect(await page.url()).toContain('/profile/edit');
+    expect(await page.content()).toContain(env.testUserNameGiven);
+    expect(await page.content()).toContain(env.testUserNameFamily);
+    expect(await page.content()).toContain('Manage basic info');
+  });
+
+  it('allows user to add a recovery email address', async () => {
+    const randomValue = Math.floor(Math.random() * 100000);
+    const randomEmail = `fake${randomValue}@example.com`;
+
+    const email = await page.$('#email_new');
+    await email.click({ clickCount: 3 });
+    await email.type(randomEmail);
+
+    await page.click('.t-btn-update-email');
+    await page.waitForSelector('.t-page--profile-edit');
+    expect(await page.url()).toContain('/profile/edit');
+    expect(await page.content()).toContain(`A confirmation email has been sent to ${randomEmail}`);
+  });
+
+  it('allows user to confirm email address via confirmation link', async () => {
+    const message = await utils.openMailhogMessage(page, 3);
+
+    // Grab the email confirmation URL and visit it.
+    const confirmationUrl = await message.$eval('p:nth-child(3) a', el => el.innerText);
+    await page.goto(confirmationUrl.replace('.test', '.test:8080'));
+
+    await page.waitForSelector('.t-page--profile-edit');
+    expect(await page.url()).toContain('/profile/edit');
+    expect(await page.content()).toContain('Thank you for confirming your email address.');
+  });
+
+  it('successfully cleaned up Mailhog', async () => {
+    await utils.clearMailhog(page, expect);
+  });
+});

--- a/_tests/e2e/_env/index.js
+++ b/_tests/e2e/_env/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-unresolved */
+
 //
 // Import any possible environment.
 //

--- a/_tests/e2e/_env/index.js
+++ b/_tests/e2e/_env/index.js
@@ -1,8 +1,17 @@
 //
-// This should pick up the value of your NODE_ENV.
+// Import any possible environment.
 //
-// Defaults to 'local'
+import local from './local';
+
 //
-import env from './example';
+// Provide config for any environment here. It will be loaded dynamically based
+// on the process.env.NODE_ENV when it runs. Defaults to `local`
+//
+const environments = {
+  local,
+};
+
+const environmentExists = typeof environments[process.env.NODE_ENV] !== 'undefined';
+const env = environmentExists ? environments[process.env.NODE_ENV] : environments.local;
 
 module.exports = env;

--- a/_tests/e2e/_utils.js
+++ b/_tests/e2e/_utils.js
@@ -1,4 +1,23 @@
+import env from './_env';
+
 /**
  * Utilities for testing HID interface
  */
-module.exports = {};
+module.exports = {
+  //
+  // Login to HID Auth.
+  //
+  async login(page) {
+    await page.goto(env.baseUrl);
+
+    const email = await page.$('#email');
+    await email.click({ clickCount: 3 });
+    await email.type(env.testUserEmail);
+
+    const password = await page.$('#password');
+    await password.click({ clickCount: 3 });
+    await password.type(env.testUserPassword);
+
+    await page.click('.t-btn--login');
+  },
+};

--- a/_tests/e2e/_utils.js
+++ b/_tests/e2e/_utils.js
@@ -20,4 +20,37 @@ module.exports = {
 
     await page.click('.t-btn--login');
   },
+
+  //
+  // Open Mailhog and return contents of the specified message. Defaults to 1st.
+  //
+  async openMailhogMessage(page, which) {
+    const whichMessage = typeof which === 'number' ? which : 1;
+
+    // Mailhog is here when you set up via hid-stack
+    await page.goto('http://localhost:8025');
+    // We always want the first message in Mailhog.
+    await page.click(`.messages > *:nth-child(${whichMessage})`);
+    // Target this message's iframe in Mailhog.
+    return page.frames()[1];
+  },
+
+
+  //
+  // Clear Mailhog.
+  //
+  async clearMailhog(page, expect) {
+    // Mailhog is here when you set up via hid-stack
+    await page.goto('http://localhost:8025');
+
+    // Delete all Mailhog messages.
+    await page.click('a[ng-click="deleteAll()"]');
+    await page.waitForTimeout(1000);
+    await page.click('.modal-dialog .btn-danger');
+    await page.waitForTimeout(1000);
+
+    // Confirm everything got cleared out.
+    const numMessages = await page.$$eval('.messages > *', el => el.length);
+    expect(numMessages).toBe(0);
+  },
 };

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1131,13 +1131,11 @@ module.exports = {
    *             required: true
    * responses:
    *   '204':
-   *     description: Email sent successfully.
+   *     description: Request to send an email confirmation was received.
    *   '400':
    *     description: Bad request.
    *   '401':
    *     description: Unauthorized.
-   *   '404':
-   *     description: Requested email address not found.
    * security: []
    */
   async sendValidationEmail(request, reply) {
@@ -1151,7 +1149,11 @@ module.exports = {
           fail: true,
         },
       );
-      throw Boom.notFound();
+
+      // Disclosing with anything other than 204 allows an attacker to determine
+      // the existence of email addresses within the system. We continue logging
+      // the email-not-found error, but publicly respond with 204.
+      return reply.response().code(204);
     }
 
     // Confirm whether the request came from a valid domain.
@@ -1178,7 +1180,8 @@ module.exports = {
       appValidationUrl,
     );
 
-    // Send a 204 (empty body)
+    // Report that the request was received. We don't want to reveal the outcome
+    // of the request, only that we understood it.
     return reply.response().code(204);
   },
 

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1115,20 +1115,6 @@ module.exports = {
    *     in: path
    *     required: true
    *     default: ''
-   * requestBody:
-   *   description: >-
-   *     The `app_validation_url` is the base URL of the confirmation link. It
-   *     must match an entry in our private `ALLOWED_DOMAINS` list, or the
-   *     request will be rejected with HTTP 400.
-   *   required: true
-   *   content:
-   *     application/json:
-   *       schema:
-   *         type: object
-   *         properties:
-   *           app_validation_url:
-   *             type: string
-   *             required: true
    * responses:
    *   '204':
    *     description: Request to send an email confirmation was received.
@@ -1156,20 +1142,6 @@ module.exports = {
       return reply.response().code(204);
     }
 
-    // Confirm whether the request came from a valid domain.
-    const appValidationUrl = request.payload && request.payload.app_validation_url ? request.payload.app_validation_url : '';
-    if (!HelperService.isAuthorizedUrl(appValidationUrl)) {
-      logger.warn(
-        `[UserController->validateEmail] app_validation_url ${appValidationUrl} is not in allowedDomains list`,
-        {
-          request,
-          security: true,
-          fail: true,
-        },
-      );
-      throw Boom.badRequest('Invalid app_validation_url');
-    }
-
     // Send validation email.
     const emailIndex = record.emailIndex(request.params.email);
     const email = record.emails[emailIndex];
@@ -1177,7 +1149,6 @@ module.exports = {
       record,
       email.email,
       email._id.toString(),
-      appValidationUrl,
     );
 
     // Report that the request was received. We don't want to reveal the outcome

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -155,7 +155,7 @@ module.exports = {
   },
 
   register(request, reply) {
-    const requestUrl = _buildRequestUrl(request, 'verify2');
+    const requestUrl = _buildRequestUrl(request, 'verify');
     return reply.view('register', {
       title: 'Register a Humanitarian ID account',
       formEmail: '',
@@ -174,7 +174,7 @@ module.exports = {
     });
     const registerLink = _getRegisterLink(request.payload);
     const passwordLink = _getPasswordLink(request.payload);
-    let requestUrl = _buildRequestUrl(request, 'verify2');
+    let requestUrl = _buildRequestUrl(request, 'verify');
 
     // Validate the visitor's response to reCAPTCHA challenge.
     try {
@@ -850,7 +850,7 @@ module.exports = {
         user,
         confirmEmail.email,
         confirmEmail._id.toString(),
-        _buildRequestUrl(request, 'verify2'),
+        _buildRequestUrl(request, 'verify'),
       ).then(() => {
         cookie.alert.message += '<p>The confirmation email will arrive in your inbox shortly.</p>';
       }).catch(() => {
@@ -865,7 +865,7 @@ module.exports = {
       await UserController.addEmail({}, {
         userId: cookie.userId,
         email: request.payload.email_new,
-        appValidationUrl: _buildRequestUrl(request, 'verify2'),
+        appValidationUrl: _buildRequestUrl(request, 'verify'),
       }).then(() => {
         cookie.alert.message += `<p>A confirmation email has been sent to ${request.payload.email_new}.</p>`;
       }).catch((err) => {

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -297,7 +297,7 @@ module.exports = {
         emailId: request.query.emailId,
       };
 
-      await UserController.validateEmail(request);
+      await UserController.validateEmailAddress(request, reply);
 
       // If user is logged in, send them to their profile.
       if (cookie && cookie.userId) {

--- a/api/services/EmailService.js
+++ b/api/services/EmailService.js
@@ -196,7 +196,7 @@ module.exports = {
       to: email,
       locale: user.locale,
     };
-    const baseUrl = `${process.env.APP_URL}/verify2`;
+    const baseUrl = `${process.env.APP_URL}/verify`;
     const hash = user.generateHash('verify_email', email);
     let resetUrl = addUrlArgument(baseUrl, 'id', user._id.toString());
     resetUrl = addUrlArgument(resetUrl, 'emailId', emailId);

--- a/api/services/EmailService.js
+++ b/api/services/EmailService.js
@@ -190,16 +190,20 @@ module.exports = {
     return send(mailOptions, 'claim', context);
   },
 
-  sendValidationEmail(user, email, emailId, appValidationUrl) {
+  sendValidationEmail(user, email, emailId) {
+    // Prepare data for the email.
     const mailOptions = {
       to: email,
       locale: user.locale,
     };
+    const baseUrl = `${process.env.APP_URL}/verify2`;
     const hash = user.generateHash('verify_email', email);
-    let resetUrl = addUrlArgument(appValidationUrl, 'id', user._id.toString());
+    let resetUrl = addUrlArgument(baseUrl, 'id', user._id.toString());
     resetUrl = addUrlArgument(resetUrl, 'emailId', emailId);
     resetUrl = addUrlArgument(resetUrl, 'time', hash.timestamp);
     resetUrl = addHash(resetUrl, hash.hash);
+
+    // Send email.
     const context = {
       user,
       reset_url: resetUrl,

--- a/config/routes.js
+++ b/config/routes.js
@@ -55,15 +55,6 @@ module.exports = [
   {
     method: 'GET',
     path: '/verify',
-    handler: ViewController.newPassword,
-    options: {
-      auth: false,
-    },
-  },
-
-  {
-    method: 'GET',
-    path: '/verify2',
     handler: ViewController.verify,
     options: {
       auth: false,

--- a/config/routes.js
+++ b/config/routes.js
@@ -471,7 +471,7 @@ module.exports = [
 
   {
     method: 'POST',
-    path: '/api/v3/user/emails/{email?}',
+    path: '/api/v3/user/emails/{email}',
     handler: UserController.sendValidationEmail,
     options: {
       auth: false,

--- a/config/routes.js
+++ b/config/routes.js
@@ -479,9 +479,17 @@ module.exports = [
   },
 
   {
-    method: 'PUT',
+    method: 'POST',
     path: '/api/v3/user/emails/{email?}',
-    handler: UserController.validateEmail,
+    handler: UserController.sendValidationEmail,
+    options: {
+      auth: false,
+    },
+  },
+  {
+    method: 'POST',
+    path: '/api/v3/user/emails/validate',
+    handler: UserController.validateEmailAddress,
     options: {
       auth: false,
     },

--- a/config/web.js
+++ b/config/web.js
@@ -67,7 +67,6 @@ module.exports = {
             '/oauth/authorize',
             '/register',
             '/verify',
-            '/verify2',
             '/password',
             '/new_password',
           ];

--- a/emails/email_validation/html.ejs
+++ b/emails/email_validation/html.ejs
@@ -2,6 +2,6 @@
 
 <p>You (or someone else) just added this email address to your profile. Please confirm this email address by clicking on the following link:</p>
 
-<a href="<%= reset_url %>"><%= reset_url %></a>
+<p><a href="<%= reset_url %>"><%= reset_url %></a></p>
 
 <% include ../includes/footer_en %>

--- a/templates/profile-edit.html
+++ b/templates/profile-edit.html
@@ -3,7 +3,7 @@
 <link rel="stylesheet" href="/assets/css/profile-edit.css">
 
 <div class="api-page">
-  <main role="main" id="main-content" class="cd-container">
+  <main role="main" id="main-content" class="cd-container t-page--profile-edit">
     <div class="cd-layout-content [ flow ]">
       <h1 class="cd-page-title page-header__heading">Edit profile</h1>
       <% include alert.html %>

--- a/templates/profile-show.html
+++ b/templates/profile-show.html
@@ -5,7 +5,7 @@
 <link rel="stylesheet" href="/assets/css/profile-show.css">
 
 <div class="api-page">
-  <main role="main" id="main-content" class="cd-container">
+  <main role="main" id="main-content" class="cd-container t-page--profile-show">
     <div class="cd-layout-content">
       <h1 class="cd-page-title page-header__heading"><%= user.name %></h1>
       <% include alert.html %>
@@ -66,4 +66,5 @@
     </div>
   </main>
 </div>
+
 <% include footer %>


### PR DESCRIPTION
# HID-2064

Marking as a draft until the open PRs are merged.

I split the route into two pieces and since we're incrementing the major version on next deploy, I took the liberty of shoving all the breaking changes into one branch.

The following endpoint is gone:
- `PUT /api/v3/user/emails/{email}`

In its place are two new ones:
- `POST /api/v3/user/emails/{email}`
- `POST /api/v3/user/emails/validate`

Not only was `PUT` inaccurate (since the email message it triggers is unique each time) but the code no longer serves two functions based on the payload you send.

## Testing

- Use API to create an email, and copy data out of Mailhog to craft the second API request.
- Use website to create an email, and click the email link to confirm an address.

Brand new E2E awaiting you, hopefully to reduce manual clicking and stuff.

```
npm run e2e -- -t "ProfileEmails"
```

## Known issues

- HID-2200: It sends "welcome to HID" emails if you use the API to reconfirm your primary. The Auth website doesn't provide that possibility so it's not common in real life.
- HID-2254: the hash does not get invalidated after the first-use. If you click the email link again, it behaves as if you never did it before, which compounds the effect of the first bug (one "welcome to HID" email for each time you click the link).