### PR TITLE
HID-2150: avoid sending email_alert messages to unconfirmed recovery addresses

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -948,13 +948,14 @@ module.exports = {
     // Send confirmation email
     await EmailService.sendValidationEmail(user, emailToAdd, savedEmailId);
 
-    // If the email sent without error, notify the other emails on this account.
+    // If the email sent without error, notify the other confirmed emails on
+    // this account.
     const promises = [];
     for (let i = 0; i < user.emails.length; i++) {
-      // TODO: probably shouldn't send notices to unconfirmed email addresses.
-      //
-      // @see HID-2150
-      promises.push(EmailService.sendEmailAlert(user, user.emails[i].email, emailToAdd));
+      const thisEmail = user.emails[i];
+      if (thisEmail.validated) {
+        promises.push(EmailService.sendEmailAlert(user, thisEmail.email, emailToAdd));
+      }
     }
 
     // Send notifications to secondary addresses.

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -833,11 +833,6 @@ module.exports = {
    *           email:
    *             type: string
    *             required: true
-   *           app_validation_url:
-   *             type: string
-   *             required: true
-   *             description: >-
-   *               Should correspond to the endpoint you are interacting with.
    * responses:
    *   '200':
    *     description: The updated user object
@@ -857,23 +852,19 @@ module.exports = {
   async addEmail(request, internalArgs) {
     let userId = '';
     let email = '';
-    let appValidationUrl = '';
 
-    // eslint-disable-next-line max-len
-    if (internalArgs && internalArgs.userId && internalArgs.email && internalArgs.appValidationUrl) {
+    if (internalArgs && internalArgs.userId && internalArgs.email) {
       userId = internalArgs.userId;
       email = internalArgs.email;
-      appValidationUrl = internalArgs.appValidationUrl;
     } else {
       userId = request.params.id;
       email = request.payload.email;
-      appValidationUrl = request.payload.app_validation_url;
     }
 
     // Is the payload complete enough to take action?
-    if (!appValidationUrl || !email) {
+    if (!email) {
       logger.warn(
-        '[UserController->addEmail] Either email or app_validation_url was not provided',
+        '[UserController->addEmail] Email was not provided',
         {
           request,
           fail: true,
@@ -883,19 +874,6 @@ module.exports = {
         },
       );
       throw Boom.badRequest('Required parameters not present in payload');
-    }
-
-    // Is the verification link pointing to a domain in our allow-list?
-    if (!HelperService.isAuthorizedUrl(appValidationUrl)) {
-      logger.warn(
-        `[UserController->addEmail] app_validation_url ${appValidationUrl} is not in allowedDomains list`,
-        {
-          request,
-          security: true,
-          fail: true,
-        },
-      );
-      throw Boom.badRequest('Invalid app_validation_url');
     }
 
     // Does the target user exist?
@@ -972,7 +950,6 @@ module.exports = {
       user,
       email,
       savedEmail._id.toString(),
-      appValidationUrl,
     );
 
     // If the email sent without error, notify the other emails on this account.

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -932,7 +932,7 @@ module.exports = {
     user.emails.push(data);
     user.lastModified = new Date();
 
-    const savedUser = await user.save();
+    await user.save();
     logger.info(
       `[UserController->addEmail] Successfully saved user ${user.id}`,
       {
@@ -942,15 +942,11 @@ module.exports = {
         },
       },
     );
-    const savedEmailIndex = savedUser.emailIndex(emailToAdd);
-    const savedEmail = savedUser.emails[savedEmailIndex];
+    const savedEmailIndex = user.emailIndex(emailToAdd);
+    const savedEmailId = user.emails[savedEmailIndex]._id.toString();
 
     // Send confirmation email
-    await EmailService.sendValidationEmail(
-      user,
-      emailToAdd,
-      savedEmail._id.toString(),
-    );
+    await EmailService.sendValidationEmail(user, emailToAdd, savedEmailId);
 
     // If the email sent without error, notify the other emails on this account.
     const promises = [];

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -868,7 +868,6 @@ module.exports = {
         user,
         confirmEmail.email,
         confirmEmail._id.toString(),
-        _buildRequestUrl(request, 'verify'),
       ).then(() => {
         cookie.alert.message += '<p>The confirmation email will arrive in your inbox shortly.</p>';
       }).catch(() => {
@@ -883,7 +882,6 @@ module.exports = {
       await UserController.addEmail({}, {
         userId: cookie.userId,
         email: request.payload.email_new,
-        appValidationUrl: _buildRequestUrl(request, 'verify'),
       }).then(() => {
         cookie.alert.message += `<p>A confirmation email has been sent to ${request.payload.email_new}.</p>`;
       }).catch((err) => {

--- a/api/services/EmailService.js
+++ b/api/services/EmailService.js
@@ -207,16 +207,16 @@ module.exports = {
     return send(mailOptions, 'claim', context);
   },
 
-  sendValidationEmail(user, email, emailId) {
+  sendValidationEmail(user, emailToValidate, emailId) {
     // Prepare data for the email.
     const mailOptions = {
-      to: email,
+      to: emailToValidate,
       locale: user.locale,
     };
 
     // Assemble values for confirmation link.
     const baseUrl = `${process.env.APP_URL}/verify`;
-    const hash = user.generateHashEmail(email);
+    const hash = user.generateHashEmail(emailToValidate);
 
     // Build confirmation link.
     let resetUrl = addUrlArgument(baseUrl, 'id', user._id.toString());

--- a/api/services/EmailService.js
+++ b/api/services/EmailService.js
@@ -213,18 +213,24 @@ module.exports = {
       to: email,
       locale: user.locale,
     };
+
+    // Assemble values for confirmation link.
     const baseUrl = `${process.env.APP_URL}/verify`;
     const hash = user.generateHashEmail(email);
+
+    // Build confirmation link.
     let resetUrl = addUrlArgument(baseUrl, 'id', user._id.toString());
     resetUrl = addUrlArgument(resetUrl, 'emailId', emailId);
     resetUrl = addUrlArgument(resetUrl, 'time', hash.timestamp);
-    resetUrl = addHash(resetUrl, hash.hash);
+    resetUrl = addUrlArgument(resetUrl, 'hash', hash.hash);
 
-    // Send email.
+    // Assemble email values.
     const context = {
       user,
       reset_url: resetUrl,
     };
+
+    // Send email
     return send(mailOptions, 'email_validation', context);
   },
 


### PR DESCRIPTION
# HID-2150

Previously, when you added a recovery email to your account, every email on your profile got a message notifying you about it. The PR prevents unconfirmed addresses from getting such messages.

## Testing

1. On your local, delete all the recovery emails on a test account of your choosing, so that only the primary remains.
2. Now, add a recovery email to that account. Auth or API calls are both fine. Do NOT confirm it by clicking link in Mailhog.
3. Add another recovery email (skip confirmation)
4. Add another recovery email (skip confirmation)
5. Check Mailhog and see that only _confirmed_ addresses are getting emails with subject line "Security alert for your HID profile" — it should be one per recovery email which will be mentioned in the message body.

