### PR TITLE
HID-2255: server-side validation of password reset, plus restore client-side validation

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1551,7 +1551,7 @@ module.exports = {
     // Update user in DB.
     await user.save().then(() => {
       logger.info(
-        `[UserController->resetPassword] Password updated successfully for user ${user.id}`,
+       '[UserController->resetPassword] Password updated successfully',
         {
           request,
           security: true,

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1551,7 +1551,7 @@ module.exports = {
     // Update user in DB.
     await user.save().then(() => {
       logger.info(
-       '[UserController->resetPassword] Password updated successfully',
+        '[UserController->resetPassword] Password updated successfully',
         {
           request,
           security: true,

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1363,6 +1363,9 @@ module.exports = {
    *           password:
    *             type: string
    *             required: true
+   *           confirm_password:
+   *             type: string
+   *             required: true
    *           emailId:
    *             type: string
    *             required: false
@@ -1388,6 +1391,7 @@ module.exports = {
       !request.payload
       || !request.payload.hash
       || !request.payload.password
+      || !request.payload.confirm_password
       || !request.payload.id
       || !request.payload.time
     ) {
@@ -1482,17 +1486,35 @@ module.exports = {
     // reset attempt should be rejected, since the passwords are the same.
     if (user.validPassword(request.payload.password)) {
       logger.warn(
-        `[UserController->resetPassword] Could not reset password for user ${request.payload.id}. The new password can not be the same as the old one`,
+        '[UserController->resetPassword] Could not reset password. The new password can not be the same as the old one.',
         {
           request,
           security: true,
           fail: true,
           user: {
             id: request.payload.id,
+            email: user.email,
           },
         },
       );
       throw Boom.badRequest(cannotResetPasswordMessage);
+    }
+
+    // Ensure that people submitting forms filled the two fields in identically.
+    if (request.payload.password !== request.payload.confirm_password) {
+      logger.warn(
+        '[UserController->resetPassword] Could not reset password. The two password values did not match.',
+        {
+          request,
+          security: true,
+          fail: true,
+          user: {
+            id: request.payload.id,
+            email: user.email,
+          },
+        },
+      );
+      throw Boom.badRequest('The password and password-confirmation fields did not match.');
     }
 
     // Success! We are resetting the password

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -529,7 +529,7 @@ module.exports = {
           },
           query: request.payload,
           isSuccess: true,
-          title: 'Password update',
+          title: 'Password reset',
         });
       } catch (err) {
         logger.warn(
@@ -542,11 +542,18 @@ module.exports = {
           },
         );
 
+        // Look at the nature of the error and show user feedback.
+        let userFacingMessage = 'There was an error resetting your password. Please try again.';
+        if (err.message === 'The password and password-confirmation fields did not match.') {
+          userFacingMessage = err.message;
+        }
+
         if (params) {
           return reply.view('login', {
             alert: {
               type: 'error',
-              message: 'There was an error resetting your password. Please try again.',
+              message: userFacingMessage,
+              error_type: 'PW-RESET-INVALID',
             },
             query: request.payload,
             registerLink,
@@ -558,7 +565,8 @@ module.exports = {
         return reply.view('password', {
           alert: {
             type: 'error',
-            message: 'There was an error resetting your password. Please try again.',
+            message: userFacingMessage,
+            error_type: 'PW-RESET-INVALID',
           },
           query: request.payload,
           requestUrl,
@@ -570,10 +578,11 @@ module.exports = {
       alert: {
         type: 'error',
         message: 'There was an error resetting your password.',
+        error_type: 'PW-RESET-GENERAL',
       },
       query: request.payload,
       isSuccess: false,
-      title: 'Password update',
+      title: 'Password reset',
     });
   },
 

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -543,9 +543,14 @@ module.exports = {
         );
 
         // Look at the nature of the error and show user feedback.
-        let userFacingMessage = 'There was an error resetting your password. Please try again.';
+        let userFacingMessage = '<p>There was an error resetting your password. Please try again.</p>';
+        let userFacingError = 'PW-RESET-INVALID';
+
+        // If fields didn't match, it's safe to disclose plus our user feedback
+        // is clear enough that we probably don't need to show an error code.
         if (err.message === 'The password and password-confirmation fields did not match.') {
-          userFacingMessage = err.message;
+          userFacingMessage = `<p>${err.message}</p>`;
+          userFacingError = undefined;
         }
 
         if (params) {
@@ -553,7 +558,7 @@ module.exports = {
             alert: {
               type: 'error',
               message: userFacingMessage,
-              error_type: 'PW-RESET-INVALID',
+              error_type: userFacingError,
             },
             query: request.payload,
             registerLink,
@@ -566,7 +571,7 @@ module.exports = {
           alert: {
             type: 'error',
             message: userFacingMessage,
-            error_type: 'PW-RESET-INVALID',
+            error_type: userFacingError,
           },
           query: request.payload,
           requestUrl,

--- a/assets/js/passwords.js
+++ b/assets/js/passwords.js
@@ -1,41 +1,49 @@
-/* eslint-disable no-unused-vars, no-param-reassign */
+(function iife() {
+  /**
+   * Find the form in the DOM.
+   */
+  var newPasswordForm = document.querySelector('#resetPassword');
 
-//
-// Password strength
-//
-// The password strength is ultimately enforced in the HID API, but we can
-// double check here and prompt the user to submit a strong password beforehand.
-//
-function checkPassword(password) {
-  var passwordStrength = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$/;
-  return password.length >= 12 && passwordStrength.test(password);
-}
-
-//
-// Form validation
-//
-function checkForm(form) {
-  // Do the passwords match?
-  if (form.password.value === form.confirm_password.value) {
-    // Is the password strong enough?
-    if (checkPassword(form.password.value)) {
-      // Submit form.
-      return true;
-    }
-
-    // Password needs to be stronger.
-    alert('The password you have entered is not strong enough! Make sure it has at least 12 characters with one number, one lowercase, one uppercase, and one special character.');
-    form.password.focus();
-
-    return false;
+  /**
+   * Password strength
+   *
+   * The password strength is ultimately enforced in the HID API, but we can
+   * double check here and prompt the user to submit a strong password beforehand.
+   */
+  function checkPassword(password) {
+    var passwordStrength = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}]).+$/;
+    return password.length >= 12 && passwordStrength.test(password);
   }
 
-  // If we got here, the passwords didn't match.
-  alert('The passwords do not match. Please confirm your password by entering it again.');
-  form.confirm_password.value = '';
-  form.confirm_password.focus();
+  /**
+   * Attach validation event listener to form.
+   *
+   * When we detect a problem, we fire event.preventDefault(), which stops the
+   * form from submitting. Otherwise it will submit and proceed normally.
+   */
+  newPasswordForm.addEventListener('submit', function checkForm(ev) {
+    // Store form so we can work with it below.
+    var form = ev.target;
 
-  // If we fall through all conditions, return false and allow the HTML5 form
-  // validation to kick in.
-  return false;
-}
+    // Do the passwords match?
+    if (form.password.value !== form.confirm_password.value) {
+      alert('The passwords do not match. Please confirm your password by entering it again.');
+      form.confirm_password.value = '';
+      form.confirm_password.focus();
+
+      // Prevent form submission.
+      ev.preventDefault();
+    }
+
+    // Is the password strong enough?
+    if (!checkPassword(form.password.value)) {
+      alert('The password you have entered is not strong enough! Make sure it has at least 12 characters with one number, one lowercase, one uppercase, and one special character.');
+      form.password.focus();
+
+      // Prevent form submission.
+      ev.preventDefault();
+    }
+
+    // If we fall through all conditions, allow the HTML5 validation to kick in.
+  });
+}());

--- a/templates/alert.html
+++ b/templates/alert.html
@@ -35,8 +35,10 @@
         <div class="cd-alert__message">
           <%- alert.message %>
           <% if (typeof alert.error_type !== 'undefined') { %>
-            <p>Error type: <%- alert.error_type %></p>
-            <p>Timestamp: <%- Date.now() %></p>
+            <p>
+              Error type: <%- alert.error_type %><br>
+              Timestamp: <%- Date.now() %>
+            </p>
           <% } %>
         </div>
       </div>

--- a/templates/new_password.html
+++ b/templates/new_password.html
@@ -6,7 +6,7 @@
       <div class="[ flow ]">
         <h1 class="cd-page-title page-header__heading">Enter your new password</h1>
 
-        <form name="resetPassword" action="/new-password" method="POST" onsubmit="return checkForm(this)" class="[ flow ]">
+        <form id="resetPassword" name="resetPassword" action="/new-password" method="POST" class="[ flow ]">
           <div class="form-field">
             <label for="password">New password</label>
             <input


### PR DESCRIPTION
# HID-2255

This started out as a small fix for the CSP, which disabled our client-side validation.

Since that happened, I'd actually noticed some intermittent errors during password resets and never could figure out what it was. It ends up that we weren't enforcing the `confirm_password` field on the server, which combined with lack of client-side validation, meant it was possible to change your password to something unexpected.

PR fixes both problems: we now have both server- and client-side validation, instead of nothing at all 🙈 

This also conveniently gets included in the 4.0.0 release, since the `confirm_password` property of the payload is now required.

## Testing

Basically, just reset a user's password and fill the form out incorrectly in various ways. It should now stop you from doing anything except the right thing.

To test server-side validation of form submissions, you can comment out the client-side JS file on your local, or disable JS in the browser.