### PR TITLE
HID-2261: remove isSuccess variable from message.html

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -671,7 +671,6 @@ module.exports = {
             ${linktoPartnerSite || ''}
           `,
         },
-        isSuccess: false,
       });
     }
   },

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -523,13 +523,12 @@ module.exports = {
         }
 
         return reply.view('message', {
+          title: 'Password reset',
           alert: {
             type: 'status',
             message: 'Thank you for updating your password.',
           },
           query: request.payload,
-          isSuccess: true,
-          title: 'Password reset',
         });
       } catch (err) {
         logger.warn(
@@ -580,14 +579,13 @@ module.exports = {
     }
 
     return reply.view('message', {
+      title: 'Password reset',
       alert: {
         type: 'error',
         message: 'There was an error resetting your password.',
         error_type: 'PW-RESET-GENERAL',
       },
       query: request.payload,
-      isSuccess: false,
-      title: 'Password reset',
     });
   },
 
@@ -1517,9 +1515,8 @@ module.exports = {
 
         // Display confirmation of deletion.
         return reply.view('message', {
+          title: 'Account deleted',
           alert,
-          isSuccess: false,
-          title: 'Account Deleted',
         });
       }
 

--- a/templates/message.html
+++ b/templates/message.html
@@ -8,10 +8,6 @@
       <% } %>
 
       <% include alert.html %>
-
-      <% if (typeof isSuccess !== 'undefined') { %>
-        <p>Now you can login on <a href="https://auth.humanitarian.id">Humanitarian ID</a> or one of our <a href="https://about.humanitarian.id/partners-using-our-authentication-service" target="_blank">partner websites</a>.</p>
-      <% } %>
     </div>
   </div>
 </main>


### PR DESCRIPTION
# HID-2216

At some point I changed a conditional from checking truthiness, to checking if it existed at all. That was a no-no, and caused messages to show up when they shouldn't. In this case, when you deleted your account, the website said you can now login to HID.

After removing the instances of `isSuccess: false` which was causing it to show up _specifically when it shouldn't_, I realized there is one instance of the template left. That's after password reset. I think people will know that they can login after resetting their password, so I removed the whole thing.

## Testing

Reset the password of a random account, login with it, and delete the account. At each step, the user feedback should function, and no templating errors should occur.