### PR TITLE
HID-2262: adopt and simplify UserPolicy.canUpdate

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -974,7 +974,7 @@ module.exports = {
    * want more info about the user, use the dedicated API method:
    *
    * @see /api/v3/user/{id}
-   * @see UserController.find()
+   * @see UserController.findOne()
    */
   showAccount(request) {
     // Full user object from DB.

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -323,7 +323,7 @@ module.exports = {
    *   '404':
    *     description: Requested user not found.
    */
-  async findOne(request, reply) {
+  async findOne(request) {
     const user = await User.findById(request.params.id);
 
     // If we found a user, sanitize and return it

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -331,7 +331,7 @@ module.exports = {
     // If we found a user, sanitize and return it
     if (user) {
       logger.info(
-        '[UserController->find] Displaying one user by ID',
+        '[UserController->findOne] Displaying one user by ID',
         {
           request,
           user: {

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -237,7 +237,7 @@ module.exports = {
    *             $ref: '#/components/schemas/User'
    *   '400':
    *     description: Bad request.
-   *   '401':
+   *   '403':
    *     description: Requesting user lacks permission to query users.
    */
   async find(request, reply) {
@@ -319,6 +319,8 @@ module.exports = {
    *   '400':
    *     description: Bad request.
    *   '401':
+   *     description: Unauthorized.
+   *   '403':
    *     description: Requesting user lacks permission to view requested user.
    *   '404':
    *     description: Requested user not found.

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -347,7 +347,7 @@ module.exports = {
 
     // Finally: if we didn't find a user, send a 404.
     logger.warn(
-      `[UserController->find] Could not find user ${request.params.id}`,
+      `[UserController->findOne] Could not find user ${request.params.id}`,
       {
         request,
         fail: true,

--- a/api/policies/UserPolicy.js
+++ b/api/policies/UserPolicy.js
@@ -74,6 +74,7 @@ module.exports = {
     logger.warn(
       `[UserPolicy->canUpdate] User ${request.auth.credentials.id} can not update user ${request.params.id}`,
       {
+        request,
         security: true,
         fail: true,
       },

--- a/api/policies/UserPolicy.js
+++ b/api/policies/UserPolicy.js
@@ -70,13 +70,17 @@ module.exports = {
       return true;
     }
 
-    // Non-admins cannot update anyone but themselves.
+    // Log that this user had insufficient permissions.
     logger.warn(
       `[UserPolicy->canUpdate] User ${request.auth.credentials.id} can not update user ${request.params.id}`,
       {
         request,
         security: true,
         fail: true,
+        user: {
+          id: request.auth.credentials.id,
+          email: request.auth.credentials.email,
+        },
       },
     );
     throw Boom.forbidden();
@@ -87,6 +91,19 @@ module.exports = {
       return true;
     }
 
+    // Log that this user had insufficient permissions.
+    logger.warn(
+      `[UserPolicy->canFind] User lacks permission to search users.`,
+      {
+        request,
+        security: true,
+        fail: true,
+        user: {
+          id: request.auth.credentials.id,
+          email: request.auth.credentials.email,
+        },
+      },
+    );
     throw Boom.unauthorized();
   },
 };

--- a/api/policies/UserPolicy.js
+++ b/api/policies/UserPolicy.js
@@ -60,13 +60,6 @@ module.exports = {
     //   OR any user is targeting themselves
     // THEN are allowed to update the target user.
     if (request.auth.credentials.is_admin || request.auth.credentials.id === request.params.id) {
-      const user = await User.findById(request.params.id);
-      if (!user) {
-        logger.warn(
-          `[UserPolicy->canUpdate] User ${request.params.id} not found`,
-        );
-        throw Boom.notFound();
-      }
       return true;
     }
 

--- a/api/policies/UserPolicy.js
+++ b/api/policies/UserPolicy.js
@@ -104,6 +104,6 @@ module.exports = {
         },
       },
     );
-    throw Boom.unauthorized();
+    throw Boom.forbidden();
   },
 };

--- a/api/policies/UserPolicy.js
+++ b/api/policies/UserPolicy.js
@@ -93,7 +93,7 @@ module.exports = {
 
     // Log that this user had insufficient permissions.
     logger.warn(
-      `[UserPolicy->canFind] User lacks permission to search users.`,
+      '[UserPolicy->canFind] User lacks permission to search users.',
       {
         request,
         security: true,

--- a/api/policies/UserPolicy.js
+++ b/api/policies/UserPolicy.js
@@ -80,13 +80,16 @@ module.exports = {
   },
 
   async canFind(request) {
-    if (request.auth.credentials.is_admin) {
+    // If the acting user is an admin
+    //   OR any user is targeting themselves
+    // THEN are allowed to view the target user.
+    if (request.auth.credentials.is_admin || request.auth.credentials.id === request.params.id) {
       return true;
     }
 
     // Log that this user had insufficient permissions.
     logger.warn(
-      '[UserPolicy->canFind] User lacks permission to search users.',
+      `[UserPolicy->canFind] User ${request.auth.credentials.id} can not view other users`,
       {
         request,
         security: true,

--- a/config/routes.js
+++ b/config/routes.js
@@ -373,8 +373,19 @@ module.exports = [
 
   {
     method: 'GET',
-    path: '/api/v3/user/{id?}',
+    path: '/api/v3/user',
     handler: UserController.find,
+    options: {
+      pre: [
+        UserPolicy.canFind,
+      ],
+    },
+  },
+
+  {
+    method: 'GET',
+    path: '/api/v3/user/{id}',
+    handler: UserController.findOne,
     options: {
       pre: [
         UserPolicy.canUpdate,

--- a/config/routes.js
+++ b/config/routes.js
@@ -388,7 +388,7 @@ module.exports = [
     handler: UserController.findOne,
     options: {
       pre: [
-        UserPolicy.canUpdate,
+        UserPolicy.canFind,
       ],
       validate: {
         params: Joi.object({

--- a/config/routes.js
+++ b/config/routes.js
@@ -377,7 +377,7 @@ module.exports = [
     handler: UserController.find,
     options: {
       pre: [
-        UserPolicy.canFind,
+        UserPolicy.canUpdate,
       ],
       validate: {
         params: Joi.object({


### PR DESCRIPTION
# HID-2262

We restricted the API a little too much when we removed searching capabilities from HID Contacts. This PR restores any user's permission to GET themselves from the API.

## Testing

1. Request `GET /api/v3/user/{id}` from a regular, non-admin user. It should return the user's object as long as you send your Bearer token.
2. Change the value of `{id}` to some other value without changing the number of characters (i.e. replace any `1` with a `2`) and it should respond with 403 Forbidden.
3. Use an admin account to search for any individual user ID. All user IDs, including your own, should work.
