### PR TITLE
HPC-7918: remove deprecated fields from account.json

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -958,11 +958,8 @@ module.exports = {
         'iss',
         'sub',
         'name',
-        'family_name',
-        'given_name',
         'email',
         'email_verified',
-        'user_id',
       ],
     };
     return out;
@@ -985,13 +982,10 @@ module.exports = {
     const output = {
       id: user.id,
       sub: user.id,
+      name: user.name,
       email: user.email,
       email_verified: user.email_verified.toString(),
-      name: user.name,
-      family_name: user.family_name,
-      given_name: user.given_name,
       iss: process.env.ROOT_URL || 'https://auth.humanitarian.id',
-      user_id: user.user_id,
     };
 
     // Log the request

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 3.3.7
+  version: 4.0.0-rc1
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.8",
+  "version": "4.0.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "3.3.8",
+  "version": "4.0.0-rc1",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
# [HPC-7918](https://humanitarian.atlassian.net/browse/HPC-7918)

Final cleanup for HIDv3 migration. Removes the following fields from `account.json` so that we can complete our DB pruning:

- `given_name`
- `family_name`
- `user_id`