### PR TITLE
HPC-7918: remove deprecated fields from account.json

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -957,11 +957,8 @@ module.exports = {
         'iss',
         'sub',
         'name',
-        'family_name',
-        'given_name',
         'email',
         'email_verified',
-        'user_id',
       ],
     };
     return out;
@@ -984,13 +981,10 @@ module.exports = {
     const output = {
       id: user.id,
       sub: user.id,
+      name: user.name,
       email: user.email,
       email_verified: user.email_verified.toString(),
-      name: user.name,
-      family_name: user.family_name,
-      given_name: user.given_name,
       iss: process.env.ROOT_URL || 'https://auth.humanitarian.id',
-      user_id: user.user_id,
     };
 
     // Log the request


### PR DESCRIPTION
# [HPC-7918](https://humanitarian.atlassian.net/browse/HPC-7918)

Final cleanup for HIDv3 migration. Removes the following fields from `account.json` so that we can complete our DB pruning:

- `given_name`
- `family_name`
- `user_id`