### PR TITLE
HID-2260: implement session storage backend using Redis

### DIFF
--- a/api/controllers/AdminController.js
+++ b/api/controllers/AdminController.js
@@ -38,7 +38,7 @@ module.exports = {
   async adminOauthClients(request, reply) {
     // Load user cookie. Redirect to homepage when no cookie found.
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[AdminController->adminOauthClients] User did not have a valid session. Redirecting to login.',
         {
@@ -123,7 +123,7 @@ module.exports = {
   async adminOauthClientEdit(request, reply) {
     // Load user cookie. Redirect to homepage when no cookie found.
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       return reply.redirect('/');
     }
 
@@ -217,7 +217,7 @@ module.exports = {
   async adminOauthClientEditSubmit(request, reply) {
     // Load user cookie. Redirect to homepage when no cookie found.
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       return reply.redirect('/');
     }
 

--- a/api/controllers/AdminController.js
+++ b/api/controllers/AdminController.js
@@ -39,23 +39,32 @@ module.exports = {
     // Load user cookie. Redirect to homepage when no cookie found.
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      logger.info(
+        '[AdminController->adminOauthClients] User did not have a valid session. Redirecting to login.',
+        {
+          request,
+          fail: true,
+          security: true,
+        },
+      );
+
       return reply.redirect('/');
     }
 
     // Load current user from DB. We do this now in order to log user metadata,
     // and also so that the error page can still display the logged-in state of
     // the non-admin users.
-    const user = await User.findOne({ _id: cookie.userId });
+    const user = await User.findById(cookie.userId);
 
     // Check user authentication and admin permissions.
     try {
       AuthPolicy.isLoggedInAsAdmin(user);
     } catch (err) {
       logger.warn(
-        '[AdminController->adminOauthClients] Non-admin attempted to access admin area',
+        '[AdminController->adminOauthClients] Non-admin attempted to access admin area.',
         {
-          security: true,
           fail: true,
+          security: true,
           user: {
             id: cookie.userId,
             email: user.email,

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -471,6 +471,7 @@ module.exports = {
     try {
       const oauth = request.server.plugins['hapi-oauth2orize'];
       const prompt = request.query.prompt ? request.query.prompt : '';
+      const redirectUrl = `${request.query.redirect_uri}?state=${request.query.state}&scope=${request.query.scope}&nonce=${request.query.nonce}`;
 
       // Check response_type
       if (!request.query.response_type) {
@@ -486,13 +487,7 @@ module.exports = {
           },
         );
 
-        return reply.redirect(
-          `${request.query.redirect_uri
-          }?error=invalid_request&state=${request.query.state
-          }&scope=${request.query.scope
-          }&nonce=${request.query.nonce
-          }`,
-        );
+        return reply.redirect(`${redirectUrl}&error=invalid_request`);
       }
 
       // If the user is not authenticated, redirect to the login page and preserve
@@ -501,14 +496,9 @@ module.exports = {
       if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp) || prompt === 'login') {
         // If user is not logged in and prompt is set to none, throw an error message.
         if (prompt === 'none') {
-          return reply.redirect(
-            `${request.query.redirect_uri
-            }?error=login_required&state=${request.query.state
-            }&scope=${request.query.scope
-            }&nonce=${request.query.nonce
-            }`,
-          );
+          return reply.redirect(`${redirectUrl}&error=login_required`);
         }
+
         logger.info(
           '[AuthController->authorizeDialogOauth2] Get request to /oauth/authorize without session. Redirecting to the login page.',
           {
@@ -638,13 +628,7 @@ module.exports = {
 
       // If prompt === none, redirect immediately.
       if (prompt === 'none') {
-        return reply.redirect(
-          `${request.query.redirect_uri
-          }?error=interaction_required&state=${request.query.state
-          }&scope=${request.query.scope
-          }&nonce=${request.query.nonce
-          }`,
-        );
+        return reply.redirect(`${redirectUrl}&error=interaction_required`);
       }
 
       // The user has not confirmed authorization, so display the authorization

--- a/api/controllers/TOTPController.js
+++ b/api/controllers/TOTPController.js
@@ -73,6 +73,7 @@ module.exports = {
         security: true,
         user: {
           id: user.id,
+          email: user.email,
         },
       },
     );

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -635,7 +635,7 @@ module.exports = {
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
       logger.info(
-        '[ViewController->user] User tried to view dashboard without session. Redirecting to login.',
+        '[ViewController->user] User had no session. Redirecting to login.',
         {
           request,
         },
@@ -679,6 +679,12 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      logger.info(
+        '[ViewController->profile] User had no session. Redirecting to login.',
+        {
+          request,
+        },
+      );
       return reply.redirect('/');
     }
 
@@ -706,6 +712,12 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      logger.info(
+        '[ViewController->profileEdit] User had no session. Redirecting to login.',
+        {
+          request,
+        },
+      );
       return reply.redirect('/');
     }
 
@@ -734,6 +746,12 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      logger.info(
+        '[ViewController->profileEditSubmit] User had no session. Redirecting to login.',
+        {
+          request,
+        },
+      );
       return reply.redirect('/');
     }
 
@@ -829,6 +847,12 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      logger.info(
+        '[ViewController->profileEmailsSubmit] User had no session. Redirecting to login.',
+        {
+          request,
+        },
+      );
       return reply.redirect('/');
     }
 
@@ -992,6 +1016,12 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      logger.info(
+        '[ViewController->settings] User had no session. Redirecting to login.',
+        {
+          request,
+        },
+      );
       return reply.redirect('/');
     }
 
@@ -1020,6 +1050,12 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      logger.info(
+        '[ViewController->settingsOauthSubmit] User had no session. Redirecting to login.',
+        {
+          request,
+        },
+      );
       return reply.redirect('/');
     }
 
@@ -1091,6 +1127,12 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      logger.info(
+        '[ViewController->settingsPassword] User had no session. Redirecting to login.',
+        {
+          request,
+        },
+      );
       return reply.redirect('/');
     }
 
@@ -1132,6 +1174,12 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      logger.info(
+        '[ViewController->settingsPasswordSubmit] User had no session. Redirecting to login.',
+        {
+          request,
+        },
+      );
       return reply.redirect('/');
     }
 
@@ -1243,6 +1291,12 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      logger.info(
+        '[ViewController->settingsSecurity] User had no session. Redirecting to login.',
+        {
+          request,
+        },
+      );
       return reply.redirect('/');
     }
 
@@ -1306,6 +1360,12 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      logger.info(
+        '[ViewController->settingsSecuritySubmit] User had no session. Redirecting to login.',
+        {
+          request,
+        },
+      );
       return reply.redirect('/');
     }
 
@@ -1452,6 +1512,12 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
     if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      logger.info(
+        '[ViewController->settingsDelete] User had no session. Redirecting to login.',
+        {
+          request,
+        },
+      );
       return reply.redirect('/');
     }
 
@@ -1490,6 +1556,12 @@ module.exports = {
       // If the user is not authenticated, redirect to the login page
       const cookie = request.yar.get('session');
       if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+        logger.info(
+          '[ViewController->settingsDeleteSubmit] User had no session. Redirecting to login.',
+          {
+            request,
+          },
+        );
         return reply.redirect('/');
       }
 

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -3,6 +3,7 @@
  * @description Controller for pages that visitors see.
  */
 const Boom = require('@hapi/boom');
+const Hoek = require('@hapi/hoek');
 const Recaptcha = require('recaptcha2');
 const Client = require('../models/Client');
 const User = require('../models/User');
@@ -147,7 +148,7 @@ module.exports = {
 
   async logout(request, reply) {
     // Temporarily store user session for logging purposes.
-    const cookie = request.yar.get('session');
+    const oldCookie = Hoek.clone(request.yar.get('session'));
 
     // Destroy user session.
     request.yar.reset();
@@ -176,7 +177,7 @@ module.exports = {
             {
               request,
               user: {
-                id: cookie.userId,
+                id: oldCookie && oldCookie.userId,
               },
             },
           );
@@ -206,7 +207,7 @@ module.exports = {
       {
         request,
         user: {
-          id: cookie.userId,
+          id: oldCookie && oldCookie.userId,
         },
       },
     );

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -648,7 +648,7 @@ module.exports = {
   async user(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId) {
       logger.info(
         '[ViewController->user] User had no session. Redirecting to login.',
         {
@@ -693,7 +693,7 @@ module.exports = {
   async profile(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId) {
       logger.info(
         '[ViewController->profile] User had no session. Redirecting to login.',
         {
@@ -726,7 +726,7 @@ module.exports = {
   async profileEdit(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId) {
       logger.info(
         '[ViewController->profileEdit] User had no session. Redirecting to login.',
         {
@@ -760,7 +760,7 @@ module.exports = {
   async profileEditSubmit(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId) {
       logger.info(
         '[ViewController->profileEditSubmit] User had no session. Redirecting to login.',
         {
@@ -861,7 +861,7 @@ module.exports = {
   async profileEmailsSubmit(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId) {
       logger.info(
         '[ViewController->profileEmailsSubmit] User had no session. Redirecting to login.',
         {
@@ -1030,7 +1030,7 @@ module.exports = {
   async settings(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId) {
       logger.info(
         '[ViewController->settings] User had no session. Redirecting to login.',
         {
@@ -1064,7 +1064,7 @@ module.exports = {
   async settingsOauthSubmit(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId) {
       logger.info(
         '[ViewController->settingsOauthSubmit] User had no session. Redirecting to login.',
         {
@@ -1141,7 +1141,7 @@ module.exports = {
   async settingsPassword(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId) {
       logger.info(
         '[ViewController->settingsPassword] User had no session. Redirecting to login.',
         {
@@ -1188,7 +1188,7 @@ module.exports = {
   async settingsPasswordSubmit(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId) {
       logger.info(
         '[ViewController->settingsPasswordSubmit] User had no session. Redirecting to login.',
         {
@@ -1305,7 +1305,8 @@ module.exports = {
   async settingsSecurity(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+
+    if (!cookie || !cookie.userId) {
       logger.info(
         '[ViewController->settingsSecurity] User had no session. Redirecting to login.',
         {
@@ -1323,7 +1324,6 @@ module.exports = {
     if (cookie.alert) {
       alert = cookie.alert;
       delete cookie.alert;
-      request.yar.set('session', cookie);
     }
 
     // Check if we need TOTP Prompt.
@@ -1331,7 +1331,6 @@ module.exports = {
     if (cookie.totpPrompt) {
       totpPrompt = true;
       delete cookie.totpPrompt;
-      request.yar.set('session', cookie);
     }
 
     // Check which step of 2FA process we're on
@@ -1339,7 +1338,6 @@ module.exports = {
     if (cookie.step) {
       step = cookie.step;
       delete cookie.step;
-      request.yar.set('session', cookie);
     }
 
     // See if we have formData to send
@@ -1347,8 +1345,10 @@ module.exports = {
     if (cookie.formData) {
       formData = cookie.formData;
       delete cookie.formData;
-      request.yar.set('session', cookie);
     }
+
+    // Finalize cookie data
+    request.yar.set('session', cookie);
 
     // Status is a user-facing label
     const status = user.totp ? 'enabled' : 'disabled';
@@ -1374,7 +1374,8 @@ module.exports = {
   async settingsSecuritySubmit(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+
+    if (!cookie || !cookie.userId) {
       logger.info(
         '[ViewController->settingsSecuritySubmit] User had no session. Redirecting to login.',
         {
@@ -1526,7 +1527,7 @@ module.exports = {
   async settingsDelete(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+    if (!cookie || !cookie.userId) {
       logger.info(
         '[ViewController->settingsDelete] User had no session. Redirecting to login.',
         {
@@ -1570,7 +1571,7 @@ module.exports = {
     try {
       // If the user is not authenticated, redirect to the login page
       const cookie = request.yar.get('session');
-      if (!cookie || (cookie && !cookie.userId) || (cookie && !cookie.totp)) {
+      if (!cookie || !cookie.userId) {
         logger.info(
           '[ViewController->settingsDeleteSubmit] User had no session. Redirecting to login.',
           {

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -87,6 +87,13 @@ module.exports = {
 
     // User is logged in, but TOTP challenge is not answered yet.
     if (cookie && cookie.userId && cookie.totp === false) {
+      logger.info(
+        '[ViewController->login] Displaying TOTP prompt.',
+        {
+          request,
+        },
+      );
+
       // Show TOTP form
       return reply.view('totp', {
         title: 'Enter your Authentication code',

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -77,8 +77,22 @@ module.exports = {
         }
         redirect += `&scope=${request.query.scope}`;
 
+        logger.info(
+          '[ViewController->login] User has a session. Redirecting to OAuth screen.',
+          {
+            request,
+          },
+        );
+
         return reply.redirect(redirect);
       }
+
+      logger.info(
+        '[ViewController->login] User has a session. Redirecting to dashboard.',
+        {
+          request,
+        },
+      );
 
       // It seems like the user navigated to HID themselves and is just logging
       // in by their own choice. Show user dashboard.

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -72,10 +72,10 @@ module.exports = {
         redirect += `?client_id=${request.query.client_id}`;
         redirect += `&redirect_uri=${request.query.redirect_uri}`;
         redirect += `&response_type=${request.query.response_type}`;
+        redirect += `&scope=${request.query.scope}`;
         if (request.query.state) {
           redirect += `&state=${request.query.state}`;
         }
-        redirect += `&scope=${request.query.scope}`;
 
         logger.info(
           '[ViewController->login] User has a session. Redirecting to OAuth screen.',
@@ -130,7 +130,7 @@ module.exports = {
 
     // Remove alert from cookie now that it's been queued to display.
     if (cookie) {
-      cookie.alert = false;
+      delete cookie.alert;
       request.yar.set(cookie);
     }
 

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -648,7 +648,7 @@ module.exports = {
   async user(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || !cookie.userId) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[ViewController->user] User had no session. Redirecting to login.',
         {
@@ -693,7 +693,7 @@ module.exports = {
   async profile(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || !cookie.userId) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[ViewController->profile] User had no session. Redirecting to login.',
         {
@@ -726,7 +726,7 @@ module.exports = {
   async profileEdit(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || !cookie.userId) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[ViewController->profileEdit] User had no session. Redirecting to login.',
         {
@@ -760,7 +760,7 @@ module.exports = {
   async profileEditSubmit(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || !cookie.userId) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[ViewController->profileEditSubmit] User had no session. Redirecting to login.',
         {
@@ -861,7 +861,7 @@ module.exports = {
   async profileEmailsSubmit(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || !cookie.userId) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[ViewController->profileEmailsSubmit] User had no session. Redirecting to login.',
         {
@@ -1030,7 +1030,7 @@ module.exports = {
   async settings(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || !cookie.userId) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[ViewController->settings] User had no session. Redirecting to login.',
         {
@@ -1064,7 +1064,7 @@ module.exports = {
   async settingsOauthSubmit(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || !cookie.userId) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[ViewController->settingsOauthSubmit] User had no session. Redirecting to login.',
         {
@@ -1141,7 +1141,7 @@ module.exports = {
   async settingsPassword(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || !cookie.userId) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[ViewController->settingsPassword] User had no session. Redirecting to login.',
         {
@@ -1188,7 +1188,7 @@ module.exports = {
   async settingsPasswordSubmit(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || !cookie.userId) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[ViewController->settingsPasswordSubmit] User had no session. Redirecting to login.',
         {
@@ -1306,7 +1306,7 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
 
-    if (!cookie || !cookie.userId) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[ViewController->settingsSecurity] User had no session. Redirecting to login.',
         {
@@ -1375,7 +1375,7 @@ module.exports = {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
 
-    if (!cookie || !cookie.userId) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[ViewController->settingsSecuritySubmit] User had no session. Redirecting to login.',
         {
@@ -1527,7 +1527,7 @@ module.exports = {
   async settingsDelete(request, reply) {
     // If the user is not authenticated, redirect to the login page
     const cookie = request.yar.get('session');
-    if (!cookie || !cookie.userId) {
+    if (!cookie || !cookie.userId || !cookie.totp) {
       logger.info(
         '[ViewController->settingsDelete] User had no session. Redirecting to login.',
         {
@@ -1571,7 +1571,7 @@ module.exports = {
     try {
       // If the user is not authenticated, redirect to the login page
       const cookie = request.yar.get('session');
-      if (!cookie || !cookie.userId) {
+      if (!cookie || !cookie.userId || !cookie.totp) {
         logger.info(
           '[ViewController->settingsDeleteSubmit] User had no session. Redirecting to login.',
           {

--- a/api/policies/AuthPolicy.js
+++ b/api/policies/AuthPolicy.js
@@ -153,17 +153,6 @@ module.exports = {
     throw Boom.forbidden('You need to be an admin');
   },
 
-  isAdminOrGlobalManager(request) {
-    if (!request.auth.credentials.is_admin && !request.auth.credentials.isManager) {
-      logger.warn(
-        `[AuthPolicy->isAdminOrGlobalManager] User ${request.auth.credentials.id} is neither an admin nor a global manager`,
-        { security: true, fail: true, request },
-      );
-      throw Boom.forbidden('You need to be an admin or a global manager');
-    }
-    return true;
-  },
-
   /**
    * When a user is logged into HID Auth, check their permissions for admin.
    *

--- a/config/web.js
+++ b/config/web.js
@@ -90,13 +90,15 @@ module.exports = {
     {
       plugin: yar,
       options: {
-        // Adopt our server-side cache defined in top-level `options`
         cache: {
+          // Adopt our server-side cache defined in top-level `options`.
           cache: 'session',
-          expiresIn: 4 * 60 * 60 * 1000, // 4-hour sessions
+
+          // 1-week sessions
+          expiresIn: 7 * 24 * 60 * 60 * 1000,
         },
 
-        // Force use of backend storage
+        // Force use of backend storage.
         maxCookieSize: 0,
 
         // Configure how cookies behave in browsers.

--- a/config/web.js
+++ b/config/web.js
@@ -5,6 +5,7 @@ const inert = require('@hapi/inert');
 const ejs = require('ejs');
 const vision = require('@hapi/vision');
 const yar = require('@hapi/yar');
+const CatboxRedis = require('@hapi/catbox-redis');
 const crumb = require('@hapi/crumb');
 const Scooter = require('@hapi/scooter');
 const Blankie = require('blankie');
@@ -15,7 +16,6 @@ const hapiAuthHid = require('../plugins/hapi-auth-hid');
 const Client = require('../api/models/Client');
 const OauthToken = require('../api/models/OauthToken');
 const JwtService = require('../api/services/JwtService');
-const CatboxRedis = require('@hapi/catbox-redis');
 
 module.exports = {
   /**
@@ -68,7 +68,7 @@ module.exports = {
         provider: {
           constructor: CatboxRedis,
           options: {
-            partition : 'session',
+            partition: 'session',
             host: process.env.REDIS_HOST || 'redis',
             port: process.env.REDIS_PORT || 6379,
             db: process.env.REDIS_DB || '0',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1511,6 +1511,43 @@
         }
       }
     },
+    "@hapi/catbox-redis": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-redis/-/catbox-redis-6.0.2.tgz",
+      "integrity": "sha512-jwH+A6+U+7q5g5WGEHDHmDvc3VekS3C6k+nB+u9/GNPmvuPfnVUC/I64GFhTsMMMqkwbNqzRmeQqi3s83MEsAg==",
+      "requires": {
+        "@hapi/hoek": "9.x.x",
+        "ioredis": "4.x.x",
+        "joi": "17.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+          "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+        },
+        "@hapi/topo": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+          "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        },
+        "joi": {
+          "version": "17.4.2",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
+          "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0",
+            "@hapi/topo": "^5.0.0",
+            "@sideway/address": "^4.1.0",
+            "@sideway/formula": "^3.0.0",
+            "@sideway/pinpoint": "^2.0.0"
+          }
+        }
+      }
+    },
     "@hapi/content": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
@@ -2730,6 +2767,31 @@
           }
         }
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+      "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+          "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+        }
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.2",
@@ -4081,6 +4143,11 @@
           }
         }
       }
+    },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
     },
     "co": {
       "version": "4.6.0",
@@ -6300,6 +6367,39 @@
               }
             }
           }
+        }
+      }
+    },
+    "ioredis": {
+      "version": "4.27.9",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.9.tgz",
+      "integrity": "sha512-hAwrx9F+OQ0uIvaJefuS3UTqW+ByOLyLIV+j0EH8ClNVxvFyH9Vmb08hCL4yje6mDYT5zMquShhypkd50RRzkg==",
+      "requires": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isarguments": "^3.1.0",
+        "p-map": "^2.1.0",
+        "redis-commands": "1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -8936,10 +9036,25 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
@@ -9924,6 +10039,11 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -10681,6 +10801,24 @@
       "integrity": "sha512-HgpvAmukTQW1UyZxM7PT/yLFayAN6rjTvYH13z/Ci69KfcOtv3BskRGBu7in+npzUG9XSxYAfRDtn6+p6p7tAw==",
       "requires": {
         "request": "2.x"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
       }
     },
     "regenerate": {
@@ -11674,6 +11812,11 @@
           "dev": true
         }
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "dependencies": {
     "@hapi/boom": "^7.4.3",
+    "@hapi/catbox": "^11.1.1",
+    "@hapi/catbox-redis": "^6.0.2",
     "@hapi/crumb": "^7.3.2",
     "@hapi/hapi": "^20.1.0",
     "@hapi/hoek": "^8.2.4",


### PR DESCRIPTION
# HID-2260

We found that HID has an implicit dependency on the load balancer cookies. It turns out that the session management library, `yar`, allows us to store session data up to a certain amount, 1KB. Once you exceed that limit, it starts dumping the data to a server cache, which uses container memory as its default backend.

If the load balancer stickiness gets disabled, OR if we had to scale up HID API containers due to heavy load, the user's session data has a high chance of appearing to not exist. The UX of this bug is ugly, resulting in people seeing a login form after already being logged in. Or sometimes, it looked like the login form wasn't working when the cookie limit got exceeded during login itself.

The PR enables a Redis backend for the session storage, so that all API containers can share storage, pushing and pulling data as needed. I've reconfigured the storage to be used in all cases, by setting a storage limit of 0 on the cookies themselves. I figure it's more consistent this way, and we only have one approach to debug.

Aside from Redis I added a whole lot of logs to see when pages get rendered, and also simplified the conditionals for cookies themselves, which I'd brainlessly pasted all over the place as time went on.

While we were touching session behavior, I extended the cookie lifetime from 4 hours to 1 week. I feel this is a nice UX improvement and there's no OICT policy against it that I know of.

## Testing

The PR is in draft because **the HID stack needs to be pulled to latest `main` branch, which has Redis configured** in order to test this properly. Additionally, I was told to change `env/common/etc/nginx/http.d/vhost_api.conf` to disable IP hashing, plus change the internal hostname to `api` in order to simulate the load balancer:

```diff
diff --git env/common/etc/nginx/http.d/vhost_api.conf env/common/etc/nginx/http.d/vhost_api.conf
index b2dd0cf..731083b 100644
--- env/common/etc/nginx/http.d/vhost_api.conf
+++ env/common/etc/nginx/http.d/vhost_api.conf
@@ -1,12 +1,12 @@

 upstream hid-api-backend {
-    server hid-api:3000;
-    ip_hash;
+    server api:3000;
+#    ip_hash;
 }
```

Once the stack is available, here is the procedure:

1. When starting your HID stack, use `--scale api=3` as an argument, like so: `docker-compose up -d --scale api=3` — this will create enough API containers to reproduce the bug easily.
2. Check out `dev` branch
3. Log in with a non-2FA user, navigate to `/settings/security/` and click the button to enable 2FA
4. If not the first try, after a few attempts of clicking "Enable 2FA" you should observe that the login form is displayed, instead of the 2FA activation form. This is due to the cookie data exceeding the limit, being written to container memory, which doesn't exist when a different API container serves the following page load.
5. Now check this branch out.
6. Repeat steps 3-4. You should be able to repeatedly load the 2FA form. You can simply click "Enable 2FA" and without completing the process, click the "Security" tab again, "Enable 2FA" again, etc. You should see the QR code every time, and **never** see the login form unexpectedly.
7. If you want to truly verify, open your browser devtools and click the "Enable 2FA" button. Now copy the `POST` request in the devtools as `cURL` (you can do this in Chrome, FF, or Safari). Execute the `cURL` command in your terminal.
8. Now log into the redis container `docker-compose exec redis redis-cli`
9. On the redis CLI, run `keys *` and from there run `get [KEY]` to see the data being stored. It should contain a base64-encoded PNG which represents the QR code.