### PR TITLE
HID-2216: implement one remediation measure against session fixation

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -269,7 +269,13 @@ module.exports = {
     // Grab cookie
     const cookie = request.yar.get('session');
 
-    // It looks like TOTP is needed for this user.
+    // If the user has a User ID set, and passed the optional 2FA challenge,
+    // they can be redirected immediately.
+    if (cookie && cookie.userId && cookie.totp === true) {
+      return loginRedirect(request, reply);
+    }
+
+    // The User ID is set, but it looks like 2FA is required.
     if (cookie && cookie.userId && cookie.totp === false) {
       try {
         // Prevent form spamming by counting submissions and locking accounts
@@ -362,11 +368,6 @@ module.exports = {
           alert,
         });
       }
-    }
-
-    // If the user has submitted the TOTP prompt, redirect.
-    if (cookie && cookie.userId && cookie.totp === true) {
-      return loginRedirect(request, reply);
     }
 
     try {

--- a/commands/readCookie.js
+++ b/commands/readCookie.js
@@ -16,7 +16,6 @@ const store = app.config.env.database.store;
 mongoose.connect(store.uri, store.options);
 
 async function run() {
-
   // Attempt to create new OAuth client and log the result.
   await Iron.unseal(args.cookie, process.env.COOKIE_PASSWORD, Iron.defaults).then((data) => {
     console.log('🍪', data);

--- a/commands/readCookie.js
+++ b/commands/readCookie.js
@@ -1,0 +1,41 @@
+/**
+ * @module readCookie
+ * @description Development tool to read an encrypted cookie.
+ *
+ * docker-compose exec dev node ./commands/readCookie.js
+ */
+const Iron = require('@hapi/iron');
+const mongoose = require('mongoose');
+const args = require('yargs').argv;
+const app = require('../');
+const config = require('../config/env');
+
+const { logger } = config;
+
+const store = app.config.env.database.store;
+mongoose.connect(store.uri, store.options);
+
+async function run() {
+
+  // Attempt to create new OAuth client and log the result.
+  await Iron.unseal(args.cookie, process.env.COOKIE_PASSWORD, Iron.defaults).then((data) => {
+    console.log('🍪', data);
+  }).catch((err) => {
+    logger.warn(
+      `[commands->readCookie] ${err.message}`,
+      {
+        fail: true,
+        stack_trace: err.stack,
+      },
+    );
+  });
+
+  process.exit();
+}
+
+(async function iife() {
+  await run();
+}()).catch((e) => {
+  console.log(e);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1408,11 +1408,18 @@
       }
     },
     "@hapi/b64": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
-      "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "9.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+          "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+        }
       }
     },
     "@hapi/boom": {
@@ -1761,14 +1768,43 @@
       }
     },
     "@hapi/iron": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.1.tgz",
-      "integrity": "sha512-QYfm6nofZ19pIxm8LR0lsANBabrdxqe0vUYKKI+0w9VdCetoove+dxfbLfduVDM72kh/RNOQG6E5/xyI826PcA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
       "requires": {
-        "@hapi/b64": "4.x.x",
-        "@hapi/boom": "7.x.x",
-        "@hapi/cryptiles": "4.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
+      },
+      "dependencies": {
+        "@hapi/boom": {
+          "version": "9.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+          "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/bourne": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+          "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+        },
+        "@hapi/cryptiles": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+          "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+          "requires": {
+            "@hapi/boom": "9.x.x"
+          }
+        },
+        "@hapi/hoek": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+          "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+        }
       }
     },
     "@hapi/joi": {
@@ -1977,6 +2013,28 @@
         "@hapi/hoek": "8.x.x",
         "@hapi/iron": "5.x.x",
         "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/b64": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
+          "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        },
+        "@hapi/iron": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.4.tgz",
+          "integrity": "sha512-+ElC+OCiwWLjlJBmm8ZEWjlfzTMQTdgPnU/TsoU5QsktspIWmWi9IU4kU83nH+X/SSya8TP8h8P11Wr5L7dkQQ==",
+          "requires": {
+            "@hapi/b64": "4.x.x",
+            "@hapi/boom": "7.x.x",
+            "@hapi/bourne": "1.x.x",
+            "@hapi/cryptiles": "4.x.x",
+            "@hapi/hoek": "8.x.x"
+          }
+        }
       }
     },
     "@hapi/subtext": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "keywords": [],
   "main": "index.js",
   "scripts": {
-    "dev": "node ./node_modules/nodemon/bin/nodemon.js ./server.js -e html,css,js,ejs --ignore './_tests/'",
+    "dev": "node ./node_modules/nodemon/bin/nodemon.js ./server.js -e html,css,js,ejs --ignore './_tests/' --ignore './commands/'",
     "docs": "swagger-inline './api/**/*' --base 'docs/swaggerBase.yaml' > docs/hid.yml",
     "start": "node ./server.js",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@hapi/hapi": "^20.1.0",
     "@hapi/hoek": "^8.2.4",
     "@hapi/inert": "^5.2.2",
+    "@hapi/iron": "^6.0.0",
     "@hapi/joi": "^16.1.7",
     "@hapi/scooter": "^6.0.1",
     "@hapi/vision": "^5.5.4",


### PR DESCRIPTION
# HID-2216

⚠️  This branch uses #291 as its base. It will be in Draft until that PR is merged ⚠️ 

This PR attempts to protect against some types of session hijacking, by resetting the session once a user successfully logs in. The result is that even if you stole a user's cookie during login, it won't be any good by the time they submit the form and finish the login process. They'll have a new ID and the old one won't exist.

## Testing

I added a new "command" to make testing this easier. It uses the stack environment to decrypt cookies that you receive in your browser.

1. Load HID login form in browser. Copy the `session` cookie from devtools.
2. `docker-compose exec api node commands/readCookie.js --cookie="__PASTE__"` — note the session ID that gets output.
3. Now login using the HID form. Once the page shows your user details, copy the `session` cookie again.
4. `docker-compose exec api node commands/readCookie.js --cookie="__PASTE__"` — it **MUST** be different than in Step 2.