### PR TITLE
HID-2192: remove special cases from /account.json

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -1005,26 +1005,6 @@ module.exports = {
       },
     );
 
-    // Special cases for legacy compat.
-    //
-    // @TODO: in testing this, it seems that the `currentClient` param is not
-    //        present when this function runs. Investigate whether we need these
-    //        special cases at all.
-    //
-    //        @see https://humanitarian.atlassian.net/browse/HID-2192
-    if (request.params.currentClient && (request.params.currentClient.id === 'iasc-prod' || request.params.currentClient.id === 'iasc-dev')) {
-      output.sub = user.email;
-    }
-    if (request.params.currentClient && request.params.currentClient.id === 'kaya-prod') {
-      output.name = user.name.replace(' ', '');
-    }
-    if (request.params.currentClient
-      && (request.params.currentClient.id === 'rc-shelter-database'
-        || request.params.currentClient.id === 'rc-shelter-db-2-prod'
-        || request.params.currentClient.id === 'deep-prod')) {
-      output.active = !user.deleted;
-    }
-
     // Send response
     return output;
   },

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -3,6 +3,7 @@
  * @description Controller for Authentication, both into HID and OAuth sites.
  */
 const Boom = require('@hapi/boom');
+const Hoek = require('@hapi/hoek');
 const Client = require('../models/Client');
 const Flood = require('../models/Flood');
 const JwtToken = require('../models/JwtToken');
@@ -975,7 +976,8 @@ module.exports = {
    */
   showAccount(request) {
     // Full user object from DB.
-    const user = JSON.parse(JSON.stringify(request.auth.credentials));
+    const user = Hoek.clone(request.auth.credentials);
+    const client = Hoek.clone(request.auth.artifacts);
 
     // This will be what we send back as a response.
     const output = {
@@ -989,16 +991,16 @@ module.exports = {
 
     // Log the request
     logger.info(
-      `[AuthController->showAccount] calling /account.json for ${request.auth.credentials.email}`,
+      `[AuthController->showAccount] calling /account.json for ${user.email}`,
       {
         request,
         user: {
-          id: request.auth.credentials.id,
-          email: request.auth.credentials.email,
-          admin: request.auth.credentials.is_admin,
+          id: user.id,
+          email: user.email,
+          admin: user.is_admin,
         },
         oauth: {
-          client_id: request.params.currentClient && request.params.currentClient.id,
+          client_id: client.id,
         },
       },
     );

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -1000,7 +1000,7 @@ module.exports = {
           admin: user.is_admin,
         },
         oauth: {
-          client_id: client.id,
+          client_id: client && client.id,
         },
       },
     );


### PR DESCRIPTION
# HID-2192

We asked around the team and also checked the logs. The affected variable which everything was using does not seem to ever be present in our requests nowadays.

Nevertheless I marked it as a breaking change and it will bump our API's major version. I would have liked to group it into the current release but oh well.

As a bonus, I looked into the token-to-user stuff and got the OAuth Client ID coming through via `request.auth.artifacts` which is now logged on each request to `/account.json` when you use a short-lived OAuth token.

# Testing

- **Make sure Drupal login still works.** It should log the OAuth `client_id` of the website when it logs "[AuthController->showAccount] calling /account.json for ..."
- **Make sure `GET /account.json` still works with your personal JWT** (this is technically not supposed to happen but no need to crash if it does)