### PR TITLE
HID-2276: store historical password hashes and prevent re-use

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1485,9 +1485,9 @@ module.exports = {
 
     // Compare new password to the old one. If our comparison is TRUE, then the
     // reset attempt should be rejected, since the passwords are the same.
-    if (user.validPassword(request.payload.password)) {
+    if (user.isHistoricalPassword(request.payload.password)) {
       logger.warn(
-        '[UserController->resetPassword] Could not reset password. The new password can not be the same as the old one.',
+        '[UserController->resetPassword] Could not reset password. New password must be different than previous passwords.',
         {
           request,
           security: true,

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1566,6 +1566,9 @@ module.exports = {
     return reply.response().code(204);
   },
 
+  // HID Contacts notification-related method.
+  //
+  // TODO: remove
   async notify(request) {
     const record = await User.findOne({ _id: request.params.id });
     if (!record) {

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1521,28 +1521,6 @@ module.exports = {
     // Success! We will reset both the password and other PW-related metadata.
     user.storePasswordInHistory();
     user.password = User.hashPassword(request.payload.password);
-
-    // Determine which email received the password reset from the ID, or use the
-    // primary as the default. Not using UserController.validateEmailAddress()
-    // because it has a different hash link structure than the link that the
-    // user clicked to arrive here. Our validation thus far is sufficient to
-    // prove ownership of the address.
-    //
-    // To be simplified after a safe window has passed following the deploy.
-    //
-    // @see HID-2219
-    let emailToVerify;
-    if (request.payload.emailId !== '') {
-      const emailIndexFromId = user.emailIndexFromId(request.payload.emailId);
-      emailToVerify = user.emails[emailIndexFromId].email;
-    } else {
-      emailToVerify = user.email;
-    }
-
-    // Mark the email address which received the password reset as verified.
-    user.verifyEmail(emailToVerify);
-
-    // Modify the user metadata now that password was reset.
     user.expires = new Date(0, 0, 1, 0, 0, 0);
     user.lastPasswordReset = new Date();
     user.passwordResetAlert30days = false;
@@ -1564,6 +1542,26 @@ module.exports = {
         },
       );
     });
+
+    // Determine which email received the password reset from the ID, or use the
+    // primary as the default. Not using UserController.validateEmailAddress()
+    // because it has a different hash link structure than the link that the
+    // user clicked to arrive here. Our validation thus far is sufficient to
+    // prove ownership of the address.
+    //
+    // To be simplified after a safe window has passed following the deploy.
+    //
+    // @see HID-2219
+    let emailToVerify;
+    if (request.payload.emailId !== '') {
+      const emailIndexFromId = user.emailIndexFromId(request.payload.emailId);
+      emailToVerify = user.emails[emailIndexFromId].email;
+    } else {
+      emailToVerify = user.email;
+    }
+
+    // Mark the email address which received the password reset as verified.
+    user.verifyEmail(emailToVerify);
 
     return reply.response().code(204);
   },

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1493,7 +1493,7 @@ module.exports = {
           security: true,
           fail: true,
           user: {
-            id: request.payload.id,
+            id: user.id,
             email: user.email,
           },
         },
@@ -1510,7 +1510,7 @@ module.exports = {
           security: true,
           fail: true,
           user: {
-            id: request.payload.id,
+            id: user.id,
             email: user.email,
           },
         },

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1408,7 +1408,7 @@ module.exports = {
     }
 
     // Look up user by ID.
-    let user = await User.findOne({ _id: request.payload.id }).catch((err) => {
+    let user = await User.findById(request.payload.id).catch((err) => {
       logger.error(
         `[UserController->resetPassword] ${err.message}`,
         {

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1518,7 +1518,8 @@ module.exports = {
       throw Boom.badRequest('The password and password-confirmation fields did not match.');
     }
 
-    // Success! We are resetting the password
+    // Success! We will reset both the password and other PW-related metadata.
+    user.storePasswordInHistory();
     user.password = User.hashPassword(request.payload.password);
 
     // Determine which email received the password reset from the ID, or use the

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -57,15 +57,22 @@ const trustedDeviceSchema = new Schema({
 
 const UserSchema = new Schema({
   // Legacy user_id data, to be added during migration
+  //
+  // TODO: remove
   user_id: {
     type: String,
     readonly: true,
   },
+
   // Legacy ID data, added during the migration
+  //
+  // TODO: remove
   legacyId: {
     type: String,
     readonly: true,
   },
+
+  // Given/first name.
   given_name: {
     type: String,
     trim: true,
@@ -75,6 +82,10 @@ const UserSchema = new Schema({
     },
     required: [true, 'Given name is required'],
   },
+
+  // Middle name
+  //
+  // TODO: remove.
   middle_name: {
     type: String,
     trim: true,
@@ -83,6 +94,8 @@ const UserSchema = new Schema({
       message: 'HTML code is not allowed in middle_name',
     },
   },
+
+  // Family/last name.
   family_name: {
     type: String,
     trim: true,
@@ -92,6 +105,8 @@ const UserSchema = new Schema({
     },
     required: [true, 'Family name is required'],
   },
+
+  // Full name.
   name: {
     type: String,
     validate: {
@@ -99,6 +114,8 @@ const UserSchema = new Schema({
       message: 'HTML code is not allowed in name',
     },
   },
+
+  // Primary email address.
   email: {
     type: String,
     lowercase: true,
@@ -111,62 +128,82 @@ const UserSchema = new Schema({
       message: 'email should be a valid email',
     }),
   },
+
+  // Whether the user has proven ownership of the email address by activating a
+  // confirmation link sent to the address.
   email_verified: {
     type: Boolean,
     default: false,
     readonly: true,
   },
+
   // Last time the user was reminded to verify his account
   remindedVerify: {
     type: Date,
     readonly: true,
   },
+
   // How many times the user was reminded to verify his account
   timesRemindedVerify: {
     type: Number,
     default: 0,
     readonly: true,
   },
+
   // Last time the user was reminded to update his account details
   remindedUpdate: {
     type: Date,
     readonly: true,
   },
-  // TODO: mark this as readonly after HID-1499 is fixed
+
+  // Recovery emails.
   emails: {
     type: [emailSchema],
-    // readonly: true
   },
+
+  // Hash of the current user password.
   password: {
     type: String,
   },
+
   // When a password gets updated, we store up to 5 old password hashes to meet
   // UN-OICT requirements. The user may not re-use a password until four others
   // have been set.
   oldPasswords: {
     type: Array,
   },
-  // Last time the user reset his password
+
+  // Last time the user reset their password
   lastPasswordReset: {
     type: Date,
     readonly: true,
     default: Date.now,
   },
+
+  // Whether the user received a 30-day password reset alert.
   passwordResetAlert30days: {
     type: Boolean,
     default: false,
     readonly: true,
   },
+
+  // Whether the user received a 7-day password reset alert.
   passwordResetAlert7days: {
     type: Boolean,
     default: false,
     readonly: true,
   },
+
+  // Whether the user received an alert that their password has expired.
   passwordResetAlert: {
     type: Boolean,
     default: false,
     readonly: true,
   },
+
+  // HID Contacts "bio" field
+  //
+  // TODO: remove
   notes: {
     type: String,
     validate: {
@@ -174,7 +211,10 @@ const UserSchema = new Schema({
       message: 'HTML code is not allowed in notes',
     },
   },
-  // TODO: validate timezone
+
+  // HID Contacts timezone field
+  //
+  // TODO: remove
   zoneinfo: {
     type: String,
     validate: {
@@ -182,11 +222,19 @@ const UserSchema = new Schema({
       message: 'HTML code is not allowed in zoneinfo',
     },
   },
+
+  // HID Contacts language preference
+  //
+  // TODO: remove
   locale: {
     type: String,
     enum: ['en', 'fr', 'es', 'ar'],
     default: 'en',
   },
+
+  // HID Contacts "Job Title" field
+  //
+  // TODO: remove
   job_title: {
     type: String,
     validate: {
@@ -194,6 +242,10 @@ const UserSchema = new Schema({
       message: 'HTML code is not allowed in job_title',
     },
   },
+
+  // HID Contacts secondary "Job Title" fields
+  //
+  // TODO: remove
   job_titles: {
     type: Array,
     validate: {
@@ -211,66 +263,97 @@ const UserSchema = new Schema({
       message: 'HTML in job titles is not allowed',
     },
   },
-  // Only an admin can set this
+
+  // Flag to indicate whether a user is an HID admin.
   is_admin: {
     type: Boolean,
     default: false,
     adminOnly: true,
   },
+
+  // HID Contacts legacy Manager role
+  //
+  // TODO: remove
   isManager: {
     type: Boolean,
     default: false,
     adminOnly: true,
   },
+
   expires: {
     type: Date,
     default: () => Date.now() + 7 * 24 * 60 * 60 * 1000,
     readonly: true,
   },
+
+  // HID Contacts metadata
+  //
+  // TODO: remove
   lastLogin: {
     type: Date,
     readonly: true,
   },
+
   createdBy: {
     type: Schema.ObjectId,
     ref: 'User',
     readonly: true,
   },
+
   authorizedClients: [{
     type: Schema.ObjectId,
     ref: 'Client',
   }],
+
+  // HID Contacts: internal flag indicating user was deleted.
+  //
+  // TODO: remove
   deleted: {
     type: Boolean,
     default: false,
   },
+
+  // HID Contacts: internal flag to hide a user.
+  //
+  // TODO: remove
   hidden: {
     type: Boolean,
     default: false,
     adminOnly: true,
   },
+
   // Whether the user uses TOTP for security
   totp: {
     type: Boolean,
     default: false,
   },
+
+  // TOTP config that for some reason lives outside totpConf...
   totpMethod: {
     type: String,
     enum: ['app'],
   },
+
+  // TOTP config
   totpConf: {
     type: Schema.Types.Mixed,
     readonly: true,
   },
+
+  // 2FA users can mark a browser as trusted for 30 days
   totpTrusted: {
     type: [trustedDeviceSchema],
     readonly: true,
   },
+
+  // Timestamp noting when user was last modified.
   lastModified: {
     type: Date,
     default: Date.now,
     readonly: true,
   },
+
+  // Time of last login to HID itself. No relation to OAuth logins.
   auth_time: {
     type: Date,
     readonly: true,

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -1,3 +1,4 @@
+/* eslint prefer-arrow-callback: "off", func-names: "off" */
 /**
 * @module User
 * @description User
@@ -281,7 +282,6 @@ const UserSchema = new Schema({
 // Index name with collation en_US
 UserSchema.index({ name: 1 }, { collation: { locale: 'en_US' } });
 
-/* eslint prefer-arrow-callback: "off", func-names: "off" */
 UserSchema.virtual('sub').get(function () {
   return this._id;
 });


### PR DESCRIPTION
# HID-2276

During our annual security self-assessment for OICT, this stood out as the only relevant item we don't implement. Their guidance says that users should not reuse the previous five passwords.

## Testing

- Changing password via API call should behave almost identically, but you can no longer switch between two passwords like you used to be able to. Passwords can no longer be reused and the error code remains the same, but the message says "New password must be different than previous passwords" — the old response used to be "New password is the same as old password."
- While logged-in, using the password change form at `/settings/password` will tell you that a password cannot be reused (same error text as API response)
- If you try to re-use passwords when resetting passwords via email links, it will show the less specific failure notification informing you that the password could not be changed. The new log entry will report: "[UserController->resetPassword] Could not reset password. New password must be different than previous passwords."