### PR TITLE
HID-2264: on TOTP form, checkbox to remember device now has a label

### DIFF
--- a/templates/totp.html
+++ b/templates/totp.html
@@ -13,7 +13,10 @@
           <input type="text" name="x-hid-totp" id="x-hid-totp" autocomplete="one-time-code" placeholder="Authentication code" required autofocus>
         </div>
         <div class="form-field">
-          <input type="checkbox" name="x-hid-totp-trust" id="x-hid-totp-trust" value="1"> Save this device for 30 days
+          <label for="x-hid-totp-trust">
+            <input type="checkbox" name="x-hid-totp-trust" id="x-hid-totp-trust" value="1">
+            Save this device for 30 days
+          </label>
         </div>
         <input type="hidden" name="redirect" value="<%= query.redirect %>" />
         <input type="hidden" name="client_id" value="<%= query.client_id %>" />


### PR DESCRIPTION
# HID-2264

Minor a11y/html bug: TOTP form has a checkbox to remember a device for 30 days. It was missing a `<label>`.

## Testing

2FA form should look unchanged. This is so minor that I'm just merging without review, but FYI @orakili