### PR TITLE
HID-2277: destroy session when submitting password reset form

### DIFF
--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -563,6 +563,11 @@ module.exports = {
       const passwordLink = _getPasswordLink(request.payload);
 
       try {
+        // Whatever happens, we first want to cleanup the session storage before
+        // trying to reset the password.
+        request.yar.reset('session');
+
+        // Now attempt the password reset.
         await UserController.resetPassword(request, reply);
 
         if (params) {

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -567,7 +567,7 @@ module.exports = {
     }
 
     if (cookie && cookie.hash && cookie.totp) {
-      const params = HelperService.getOauthParams(request.payload);
+      const oAuthParams = HelperService.getOauthParams(request.payload);
       const registerLink = _getRegisterLink(request.payload);
       const passwordLink = _getPasswordLink(request.payload);
 
@@ -581,7 +581,7 @@ module.exports = {
 
         // If we found OAuth params, their login form will be configured to
         // continue logging them into a Partner site.
-        if (params) {
+        if (oAuthParams) {
           return reply.view('login', {
             alert: {
               type: 'status',
@@ -625,7 +625,7 @@ module.exports = {
 
         // If we found OAuth params, their login form will be configured to
         // continue logging them into a Partner site.
-        if (params) {
+        if (oAuthParams) {
           return reply.view('login', {
             alert: {
               type: 'error',

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -447,7 +447,7 @@ module.exports = {
       hash: request.query.hash,
       id: request.query.id,
       time: request.query.time,
-      emailId: request.query.emailId,
+      emailId: request.query.emailId || '',
       totp: false,
     });
 

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -452,7 +452,7 @@ module.exports = {
     });
 
     // Look up User by ID.
-    const user = await User.findOne({ _id: request.query.id }).catch((err) => {
+    const user = await User.findById(request.query.id).catch((err) => {
       logger.error(
         `[ViewController->newPassword] ${err.message}`,
         {
@@ -535,7 +535,7 @@ module.exports = {
     // Non-2FA users
     if (cookie && cookie.hash && cookie.id && cookie.emailId && cookie.time && !cookie.totp) {
       try {
-        const user = await User.findOne({ _id: cookie.id });
+        const user = await User.findById(cookie.id);
         const token = request.payload['x-hid-totp'];
 
         // See if TOTP code is valid.


### PR DESCRIPTION
# HID-2277

I noticed that redis was holding onto some session data after a password reset took place. That shouldn't happen. PR resets sessions after password reset form is submitted. The outcome (success/error) doesn't matter. The session always gets wiped.

I also cleaned up code as went: commented parts of the function, used a better DB lookup, renamed vars to be clearer.

# Testing

The cookie that gets set when you load the password reset form (with the two password fields), should be destroyed after the form gets submitted.

1. use password reset form, click link in mailhog, open devtools for the tab and **refresh** to get a `Set-Cookie` header to decrypt
2. decrypt the session using `commands/readCookie.js` and get ID
3. look up ID in redis: `doco exec redis redis-cli`, `select 10`, `keys *`, `get SESSION_ID` where SESSION_ID matches your decrypted cookie
4. Submit password reset form. It can be successful or show an error, either way is fine.
5. Look inside `redis-cli` and run the same `get SESSION_ID` that you just looked up. It should report `(nil)` as the result this time.