### PR TITLE
HID-2292: don't show errors when everything worked just fine

### DIFF
--- a/_tests/e2e/PasswordReset.test.js
+++ b/_tests/e2e/PasswordReset.test.js
@@ -86,7 +86,7 @@ describe('PasswordReset [no-ci]', () => {
   });
 
   it('immediately shows an error when password reset link is invalid', async () => {
-    // In this case we want the SAME link as the firs time, to verify that it
+    // In this case we want the SAME link as the first time, to verify that it
     // can't be reused.
     const message = await utils.openMailhogMessage(page);
 

--- a/_tests/e2e/Register.test.js
+++ b/_tests/e2e/Register.test.js
@@ -1,0 +1,63 @@
+import env from './_env';
+import utils from './_utils';
+
+describe('Register [no-ci]', () => {
+  let page;
+
+  beforeAll(async () => {
+    page = await context.newPage();
+    await page.goto(`${env.baseUrl}/register`);
+  });
+
+  it('can be publicly accessed', async () => {
+    expect(await page.url()).toContain('/register');
+    expect(await page.content()).toContain('Register a Humanitarian ID account');
+  });
+
+  it('presents a form with email field', async () => {
+    const inputId = await page.$eval('#email', el => el.id);
+    expect(inputId).toBe('email');
+  });
+
+  it('prevents form submission when validation errors are present', async () => {
+    let emailFieldInvalid;
+
+    await page.click('.t-btn--register');
+    emailFieldInvalid = await page.$$eval('#email:invalid', el => el.length);
+    expect(emailFieldInvalid).toBeGreaterThan(0);
+
+    await page.type('#email', 'invalid-email-address');
+    await page.click('.t-btn--register');
+    emailFieldInvalid = await page.$$eval('#email:invalid', el => el.length);
+    expect(emailFieldInvalid).toBeGreaterThan(0);
+  });
+
+  it('shows positive feedback after submitting form', async () => {
+    const input = await page.$('#email');
+    await input.click({ clickCount: 3 });
+    await page.type('#email', `register${Math.floor(Math.random() * 10000)}@example.com`);
+    await page.type('#given_name', 'Registration');
+    await page.type('#family_name', 'E2E User');
+    await page.type('#password', env.testUserPassword);
+    await page.type('#confirm_password', env.testUserPassword);
+    await page.click('.t-btn--register');
+    await page.waitForTimeout(1000);
+    expect(await page.content()).toContain('Thank you for creating an account.');
+  });
+
+  it('allows user to initiate account confirmation via primary email', async () => {
+    const message = await utils.openMailhogMessage(page, 1);
+
+    // Mailhog has iframes and the link has target="_blank" and all of that makes
+    // it a real PITA to truly click the link and follow it. Let's instead grab
+    // the URL and go directly to it:
+    const confirmationUrl = await message.$eval('p:nth-child(3) a', el => el.innerText);
+    await page.goto(confirmationUrl);
+    // Do we see the password reset form?
+    expect(await page.content()).toContain('Thank you for confirming your account.');
+  });
+
+  it('successfully cleaned up Mailhog', async () => {
+    await utils.clearMailhog(page, expect);
+  });
+});

--- a/emails/register/html.ejs
+++ b/emails/register/html.ejs
@@ -2,7 +2,7 @@
 
 <p>Thank you for joining Humanitarian ID. To complete the registration, we need you to confirm your account by clicking on the link below. Please note that this is a one-time use link and it will remain valid for 24 hours.</p>
 
-<a href="<%= reset_url %>"><%= reset_url %></a>
+<p><a href="<%= reset_url %>"><%= reset_url %></a></p>
 
 <p>In case the link has expired, you can request a new one, by clicking here: <a href="https://auth.humanitarian.id/password">Request new link</a>.</p>
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -59,7 +59,7 @@
         <div class="g-recaptcha" data-sitekey="<%= recaptcha_site_key %>"></div>
         <input type="hidden" name="crumb" value="<%= crumb %>" />
         <input type="hidden" name="app_verify_url" value="<%= requestUrl %>" />
-        <button type="submit" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase">Register</button>
+        <button type="submit" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase t-btn--register">Register</button>
       </form>
     </div>
   </main>


### PR DESCRIPTION
# HID-2292

When you sign up and click the initial confirmation link, Prod currently says it's malformed. However, it DOES confirm the account and it DOES email you saying "this was successful" problem was in the code to display the success message.

Due to my own oversight, I was trying to write to a cookie object which wasn't guaranteed to exist. If you ask for the session object and none exists, it returns `null` which JS considers truthy 😠 

I patched up the problem, plus dropped an actual logging statement in our `catch` so that maybe next time I write bad code, we can see a stack trace in ELK.

## Testing

New E2E test `Register.test.js` does this:

- Open private/incognito browsing session in browser of your choice.
- Register new HID account
- Click confirmation link in mailhog
- It should report success now