### PR TITLE
HID-2269: adopt standard-version to generate CHANGELOG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,37 @@
+# Contributing Guidelines
+
+Conventions to follow during regular development.
+
+## Commit messages
+
+As of `v4.0.0` we are using [standard-version](https://github.com/conventional-changelog/standard-version#standard-version) to generate a `CHANGELOG.md` for each release. This automation is only possible if our commits follow the [Conventional Commits 1.0.0 specification](https://www.conventionalcommits.org/en/v1.0.0/).
+
+Here are a few brief examples:
+
+```sh
+#
+# All examples assume you're on version 4.0.0 when creating the example commit.
+#
+
+# a normal bugfix
+# Outcome: new patch version (4.0.1)
+git cm -m "fix: remove typo from password reset error message"
+
+# a new feature that relates to "auth"
+# Outcome: new minor version (4.1.0)
+git cm -m "feat(auth): allow new scope 'photo' when fetching account.json"
+
+# a bugfix that creates a breaking change
+# Outcome: new major version (5.0.0)
+git cm -m "fix!: remove legacy special-cases from account.json
+
+Refs: HID-XXXX
+BREAKING CHANGE: we had some special cases which reformatted fundamental 
+properties based on the client requesting the user's data. Our logs show this 
+is no longer in use so we're dropping the special cases to enforce consistency"
+
+```
+
 # Installation / Setup
 
 The best way to set up HID is by using the HID stack repo and following instructions there.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "start": "node ./server.js",
     "lint": "eslint .",
     "e2e": "jest _tests/e2e/*.test.js",
-    "test": "npm run lint && npm run e2e -- -t '^(?!.*no-ci).*$'"
+    "test": "npm run lint && npm run e2e -- -t '^(?!.*no-ci).*$'",
+    "release": "standard-version"
   },
   "dependencies": {
     "@hapi/boom": "^7.4.3",
@@ -80,6 +81,7 @@
     "minimist": "^1.2.5",
     "nodemon": "^2.0.2",
     "puppeteer": "^8.0.0",
+    "standard-version": "^9.3.2",
     "swagger-inline": "^3.0.4"
   },
   "engines": {


### PR DESCRIPTION
# HID-2269

By implementing this tool and consistently applying [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) to our commit messages, we can automatically generate a `CHANGELOG` for each release.

Since the tool is generally assumed to be run locally, I am imagining that each subsequent release will require a final PR to generate the CHANGELOG and tag, which can then be merged to `master` like the normal workflow we have in our handbook.

FYI @orakili but no code review necessary. If you have thoughts on the docs I am happy to update in a followup.