### PR TITLE
HID-2300: allow confirmed recovery email addresses to be used for logins

### DIFF
--- a/_tests/e2e/Login.test.js
+++ b/_tests/e2e/Login.test.js
@@ -37,7 +37,6 @@ describe('Login', () => {
 
   it('allows user to log in when credentials are valid', async () => {
     await utils.login(page);
-    await page.waitForSelector('.t-page--dashboard');
 
     expect(await page.url()).toContain('/user');
     expect(await page.content()).toContain(env.testUserNameGiven);

--- a/_tests/e2e/Login.test.js
+++ b/_tests/e2e/Login.test.js
@@ -48,7 +48,7 @@ describe('Login', () => {
   });
 
   it('rejects logins from unconfirmed recovery email addresses', async () => {
-    await page.type('#email', 'unconfirmed@example.com');
+    await page.type('#email', env.testUserEmailRecoveryUnconfirmed);
     const password = await page.$('#password');
     await password.click({ clickCount: 3 });
     await password.type(env.testUserPassword);
@@ -61,7 +61,23 @@ describe('Login', () => {
     expect(await page.content()).toContain('We could not log you in.');
   });
 
+  it('accepts logins from confirmed recovery email addresses', async () => {
+    await page.type('#email', env.testUserEmailRecovery);
+    const password = await page.$('#password');
+    await password.click({ clickCount: 3 });
+    await password.type(env.testUserPassword);
+    await Promise.all([
+      page.waitForNavigation(),
+      page.click('.t-btn--login'),
+    ]);
+
+    expect(await page.url()).toContain('/user');
+    expect(await page.content()).toContain(env.testUserNameGiven);
+    expect(await page.content()).toContain(env.testUserNameFamily);
+  });
+
   it('allows user to log in when credentials are valid', async () => {
+    await utils.logout(page);
     await utils.login(page);
 
     expect(await page.url()).toContain('/user');

--- a/_tests/e2e/Login.test.js
+++ b/_tests/e2e/Login.test.js
@@ -35,6 +35,32 @@ describe('Login', () => {
     expect(passwordFieldInvalid).toBeGreaterThan(0);
   });
 
+  it('rejects logins from non-existent email addresses', async () => {
+    await page.type('#email', 'not.real@example.com');
+    await page.type('#password', 'a bad password');
+    await Promise.all([
+      page.waitForNavigation(),
+      page.click('.t-btn--login'),
+    ]);
+
+    expect(await page.url()).toContain('/login');
+    expect(await page.content()).toContain('We could not log you in.');
+  });
+
+  it('rejects logins from unconfirmed recovery email addresses', async () => {
+    await page.type('#email', 'unconfirmed@example.com');
+    const password = await page.$('#password');
+    await password.click({ clickCount: 3 });
+    await password.type(env.testUserPassword);
+    await Promise.all([
+      page.waitForNavigation(),
+      page.click('.t-btn--login'),
+    ]);
+
+    expect(await page.url()).toContain('/login');
+    expect(await page.content()).toContain('We could not log you in.');
+  });
+
   it('allows user to log in when credentials are valid', async () => {
     await utils.login(page);
 

--- a/_tests/e2e/ProfileEmails.test.js
+++ b/_tests/e2e/ProfileEmails.test.js
@@ -11,7 +11,6 @@ describe('ProfileEmails', () => {
 
   it('shows user dashboard after logging in', async () => {
     await utils.login(page);
-    await page.waitForSelector('.t-page--dashboard');
 
     expect(await page.url()).toContain('/user');
     expect(await page.content()).toContain(env.testUserNameGiven);

--- a/_tests/e2e/_env/example.js
+++ b/_tests/e2e/_env/example.js
@@ -2,7 +2,7 @@ module.exports = {
   baseUrl: 'http://hid.test',
   mailhogUrl: 'http://localhost:8025',
 
-  // Users/data
+  // Standard HID user.
   testUserId: '',
   testUserNameGiven: 'Test',
   testUserNameFamily: 'E2E User',
@@ -10,6 +10,7 @@ module.exports = {
   testUserEmailRecovery: 'recovery@example.com',
   testUserPassword: '123456789aA!',
 
+  // HID Admin
   testAdminUserId: '',
   testAdminUserNameGiven: 'Admin',
   testAdminUserNameFamily: 'E2E User',

--- a/_tests/e2e/_env/example.js
+++ b/_tests/e2e/_env/example.js
@@ -8,6 +8,7 @@ module.exports = {
   testUserNameFamily: 'E2E User',
   testUserEmail: 'user@example.com',
   testUserEmailRecovery: 'recovery@example.com',
+  testUserEmailRecoveryUnconfirmed: 'unconfirmed@example.com',
   testUserPassword: '123456789aA!',
 
   // HID Admin

--- a/_tests/e2e/_utils.js
+++ b/_tests/e2e/_utils.js
@@ -5,7 +5,7 @@ import env from './_env';
  */
 module.exports = {
   //
-  // Login to HID Auth.
+  // Log in to HID Auth.
   //
   async login(page) {
     await page.goto(env.baseUrl);
@@ -20,6 +20,16 @@ module.exports = {
 
     await page.click('.t-btn--login');
     await page.waitForSelector('.t-page--dashboard');
+  },
+
+  //
+  // Log out of HID Auth.
+  //
+  async logout(page) {
+    await Promise.all([
+      page.waitForNavigation(),
+      page.goto(`${env.baseUrl}/logout`),
+    ]);
   },
 
   //

--- a/_tests/e2e/_utils.js
+++ b/_tests/e2e/_utils.js
@@ -19,6 +19,7 @@ module.exports = {
     await password.type(env.testUserPassword);
 
     await page.click('.t-btn--login');
+    await page.waitForSelector('.t-page--dashboard');
   },
 
   //

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -45,8 +45,8 @@ async function loginHelper(request) {
     return cuser;
   }
 
-  // If there has been 5 failed login attempts in the last 5 minutes, return
-  // unauthorized.
+  // Set up flood count: if there has been 5 failed login attempts in the last
+  // five minutes, prevent authorization.
   const now = Date.now();
   const offset = 5 * 60 * 1000;
   const d5minutes = new Date(now - offset);
@@ -73,6 +73,8 @@ async function loginHelper(request) {
     );
     throw Boom.tooManyRequests('Your account has been locked for 5 minutes because of too many requests.');
   }
+
+  // Was the user found?
   if (!user) {
     logger.warn(
       '[AuthController->loginHelper] Unsuccessful login attempt due to invalid email address',
@@ -105,6 +107,7 @@ async function loginHelper(request) {
     throw Boom.unauthorized('Please verify your email address');
   }
 
+  // Check that the password is valid.
   if (!user.validPassword(password)) {
     logger.warn(
       '[AuthController->loginHelper] Unsuccessful login attempt due to invalid password',
@@ -118,6 +121,7 @@ async function loginHelper(request) {
         },
       },
     );
+
     // Create a flood entry
     await Flood.create({ type: 'login', email, user });
     throw Boom.unauthorized('invalid email or password');

--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -51,12 +51,15 @@ async function loginHelper(request) {
   const offset = 5 * 60 * 1000;
   const d5minutes = new Date(now - offset);
 
-  const [number, user] = await Promise.all([
+  // Query DB for flood count and User profile which owns email address.
+  const [floodCount, user] = await Promise.all([
     Flood.countDocuments({ type: 'login', email, createdAt: { $gte: d5minutes.toISOString() } }),
     User.findOne({ 'emails.email': email }),
   ]);
 
-  if (number >= 5) {
+  // If the flood count is too high, disable further attempts until the timer
+  // gets reset.
+  if (floodCount >= 5) {
     logger.warn(
       '[AuthController->loginHelper] Account locked for 5 minutes',
       {


### PR DESCRIPTION
# HID-2300

Allowing confirmed recovery addresses to be used for login will solve a ton of support problems, in addition to allowing simplification of language across the website. There's no additional security risk because the user still has to demonstrate ownership of the email address before it can be used for login.

Per usual, there's no specific feedback in regards to why your login gets rejected. It all gets condensed into one canned response, in order to comply with OICT and follow the recommendations of our recurring independent security audits.

## Testing

```sh
npm run e2e -- -t Login
```

There are new tests which attempt the following scenarios:

- non-existent address: PREVENT login
- unconfirmed recovery used to login: PREVENT login
- confirmed recovery used to login: ALLOW log in

To get these working, your test user should have a profile that looks like the following screenshot. I tried to name the emails as plainly as possible to make it obvious! All addresses end with `example.com`:

<img width="1158" alt="Screen Shot 2021-10-26 at 12 22 41" src="https://user-images.githubusercontent.com/254753/138860143-0f464ff0-5e02-4df0-a1a3-009c40ffbeac.png">


