### PR TITLE
HID-2299: update text within email_alert notifications

### DIFF
--- a/emails/email_alert/fr/html.ejs
+++ b/emails/email_alert/fr/html.ejs
@@ -2,9 +2,9 @@
 
 <p>Vous recevez ce message parcequ'une nouvelle adresse email, <%= emailAdded %>, a été ajoutée à votre profil Humanitarian ID.</p>
 
-<p>Si vous avez effectué cette action ou demandé à un manager Humanitarian ID de l'effectuer pour vous, vous pouvez ignorer ce message.</p>
+<p>Si vous avez effectué cette action, vous pouvez ignorer ce message.</p>
 
-<p>En revanche, si l'adresse email citée ci-dessus ne vous appartient pas, contactez nous immédiatement à info@humanitarian.id !</p>
+<p>En revanche, si l'adresse email citée ci-dessus ne vous appartient pas, contactez nous immédiatement à <a href="mailto:info@humanitarian.id">info@humanitarian.id</a>.</p>
 
 <p>Cordialement,</p>
 

--- a/emails/email_alert/html.ejs
+++ b/emails/email_alert/html.ejs
@@ -1,10 +1,10 @@
 <p>Dear <%= user.name %>,</p>
 
-<p>You received this message because an additional email, <%= emailAdded %>, has been added to your profile for login purposes.</p>
+<p>You received this message because an additional email, <%= emailAdded %>, has been added to your profile.</p>
 
-<p>If you have taken this action or asked one of the Humanitarian ID Global Managers to initiate this, please disregard this email.</p>
+<p>If you have taken this action, please disregard this email.</p>
 
-<p>However, if the above is not your email address, please contact us directly at info@humanitarian.id !</p>
+<p>However, if the above is not your email address, please contact us directly at <a href="mailto:info@humanitarian.id">info@humanitarian.id</a>.</p>
 
 <p>Kind regards,</p>
 


### PR DESCRIPTION
# HID-2299

When a person adds a new recovery email address, we notify them by emailing all confirmed addresses on their profile. This PR updates the wording.

## Testing

Add an email address to any account. Note the changes to the notification in Mailhog.

The concept of non-EN locales is vestigial from HID Contacts, but nevertheless it exists. Some 4000 users still get french emails. To find a french user, run this command in the Mongo console:

```sh
# log into DB container and open a prompt
$ docker-compose exec db mongo local

# from the prompt, run this query
> db.user.findOne({ locale:'fr'},{email:true})
... result will display an email...

# use the email to initiate a password reset, then log in and add an email to the account
```