### PR TITLE
HID-2288: show password form again when any pw requirement wasn't met

### DIFF
--- a/_tests/e2e/PasswordReset.test.js
+++ b/_tests/e2e/PasswordReset.test.js
@@ -67,22 +67,20 @@ describe('PasswordReset [no-ci]', () => {
     expect(confirmInvalid).toBeGreaterThan(0);
   });
 
-  // This test assumes you are on the URL we extracted from Mailhog.
   it('allows user to reset using an approved password', async () => {
     const password = await page.$('#password');
     const confirm = await page.$('#confirm_password');
+    const validPassword = `${Math.floor(Math.random() * 10000000000)}aA!`;
 
-    // Fill in the form properly. We use the password in the env config, but
-    // reverse the string to make multuple runs a bit easier since the config
-    // can be tested, then reverted back to original in a second run.
+    // Fill in the form properly.
     await password.click({ clickCount: 3 });
-    await password.type(env.testUserPassword.split('').reverse().join(''));
+    await password.type(validPassword);
     await confirm.click({ clickCount: 3 });
-    await confirm.type(env.testUserPassword.split('').reverse().join(''));
+    await confirm.type(validPassword);
 
     await page.click('.t-btn--reset-pw');
     await page.waitForTimeout(2000);
-    expect(await page.content()).toContain('Thank you for updating your password.');
+    expect(await page.content()).toContain('Your password was successfully reset. You can now login.');
   });
 
   it('immediately shows an error when password reset link is invalid', async () => {
@@ -125,18 +123,17 @@ describe('PasswordReset [no-ci]', () => {
   it('allows user to reset using an approved password', async () => {
     const password = await page.$('#password');
     const confirm = await page.$('#confirm_password');
+    const validPassword = `${Math.floor(Math.random() * 10000000000)}aA!`;
 
-    // Fill in the form properly. We use the password in the env config, but
-    // reverse the string to make multuple runs a bit easier since the config
-    // can be tested, then reverted back to original in a second run.
+    // Fill in the form properly.
     await password.click({ clickCount: 3 });
-    await password.type(env.testUserPassword);
+    await password.type(validPassword);
     await confirm.click({ clickCount: 3 });
-    await confirm.type(env.testUserPassword);
+    await confirm.type(validPassword);
 
     await page.click('.t-btn--reset-pw');
     await page.waitForTimeout(2000);
-    expect(await page.content()).toContain('Thank you for updating your password.');
+    expect(await page.content()).toContain('Your password was successfully reset. You can now login.');
   });
 
   it('successfully cleaned up Mailhog', async () => {

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -1389,7 +1389,7 @@ module.exports = {
     const cookie = request.yar.get('session');
 
     // There are several reasons we might want to return some responses from the
-    // API, but we want to ensure the messages are identical so that an error
+    // API, but we want to ensure the messages are identical so that an errors
     // with a sensitive nature can't be inferred from the public response.
     const resetLinkInvalidMessage = 'Reset password link is expired or invalid';
     const cannotResetPasswordMessage = 'Could not reset password';

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -519,7 +519,7 @@ module.exports = {
           type: 'warning',
           title: 'Enter your two-factor authentication code.',
           message: `
-            <p><a href="https://about.humanitarian.id/faqs.html#What-two-factor-authentication" target="_blank" rel="noopener noreferrer">Read about 2FA in our FAQs</a></p>
+            <p><a href="https://about.humanitarian.id/faqs#2fa" target="_blank" rel="noopener noreferrer">Read about 2FA in our FAQs</a></p>
           `,
         },
       });
@@ -583,6 +583,7 @@ module.exports = {
       }
     }
 
+    // Was 2FA entered correctly?
     if (cookie && cookie.hash && cookie.totp) {
       const oAuthParams = HelperService.getOauthParams(request.payload);
       const registerLink = _getRegisterLink(request.payload);

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -589,12 +589,11 @@ module.exports = {
       const passwordLink = _getPasswordLink(request.payload);
 
       try {
-        // Whatever happens, we first want to cleanup the session storage before
-        // trying to reset the password.
-        request.yar.reset('session');
-
         // Now attempt the password reset.
         await UserController.resetPassword(request, reply);
+
+        // If reset was successful, we want to cleanup the session storage.
+        request.yar.reset('session');
 
         // If we found OAuth params, their login form will be configured to
         // continue logging them into a Partner site.

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -549,7 +549,7 @@ module.exports = {
   async newPasswordPost(request, reply) {
     const cookie = request.yar.get('session');
 
-    // Non-2FA users
+    // If 2FA challenge has not yet been passed.
     if (cookie && cookie.hash && cookie.id && cookie.emailId && cookie.time && !cookie.totp) {
       try {
         const user = await User.findById(cookie.id);
@@ -583,7 +583,7 @@ module.exports = {
       }
     }
 
-    // Was 2FA entered correctly?
+    // Was 2FA entered correctly, or not necessary?
     if (cookie && cookie.hash && cookie.totp) {
       const oAuthParams = HelperService.getOauthParams(request.payload);
       const registerLink = _getRegisterLink(request.payload);

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -629,9 +629,14 @@ module.exports = {
           },
         );
 
-        // Look at the nature of the error and show user feedback.
         let userFacingMessage = '<p>There was an error resetting your password. Please try again.</p>';
-        let userFacingError = 'PW-RESET-INVALID';
+        let userFacingError = 'PW-RESET-GENERAL';
+
+        // Look at the nature of the error and show user feedback.
+        if (err.message === 'Could not reset password') {
+          userFacingMessage = '<p>The password did not meet our guidelines. Please try again.</p>';
+          userFacingError = 'PW-RESET-INVALID';
+        }
 
         // If fields didn't match, it's safe to disclose plus our user feedback
         // is clear enough that we probably don't need to show an error code.

--- a/templates/new-password.html
+++ b/templates/new-password.html
@@ -7,6 +7,8 @@
       <div class="[ flow ]">
         <h1 class="cd-page-title page-header__heading">Enter your new password</h1>
 
+        <% include alert.html %>
+
         <form id="passwordForm" name="resetPassword" action="/new-password" method="POST" class="[ flow ]">
           <div class="form-field">
             <label for="password">New password</label>
@@ -23,6 +25,7 @@
               <span class="visually-hidden">Toggle password visibility</span>
             </button>
           </div>
+
           <div class="form-field">
             <label for="confirm_password">Confirm new password</label>
             <input
@@ -41,16 +44,13 @@
           <div class="form-field">
             <% include includes/password-requirements.html %>
           </div>
-          <input type="hidden" name="redirect" value="<%= query.redirect %>" />
-          <input type="hidden" name="client_id" value="<%= query.client_id %>" />
-          <input type="hidden" name="redirect_uri" value="<%= query.redirect_uri %>" />
-          <input type="hidden" name="response_type" value="<%= query.response_type %>" />
-          <input type="hidden" name="scope" value="<%= query.scope %>" />
+
           <input type="hidden" name="hash" value="<%= hash %>" />
           <input type="hidden" name="id" value="<%= id %>" />
           <input type="hidden" name="emailId" value="<%= emailId %>" />
           <input type="hidden" name="time" value="<%= time %>" />
           <input type="hidden" name="crumb" value="<%= crumb %>" />
+
           <button type="submit" class="cd-button cd-button--bold cd-button--wide cd-button--uppercase t-btn--reset-pw">Reset password</button>
         </form>
       </div>


### PR DESCRIPTION
# HID-2288

The password reset process is hopefully a lot smoother now. When you fail to meet all password requirements (complexity or re-use) the error is more specific and it now shows the password reset form, instead of forcing you to generate a new link and start over from the beginning.

When you're successful, it drops you directly on the login screen.

## Testing

Test the process with 2FA/non-2FA.

1. Reset password with regular user. Note the password you choose.
2. Do another password reset. Use SAME password. It should show the following:

<img width="651" alt="Screen Shot 2021-10-29 at 12 52 48" src="https://user-images.githubusercontent.com/254753/139422661-436a12fa-74b6-4c41-8c63-bcdfb363af10.png">

3. Enter a new, valid password. It should show the success message on the login page now:

<img width="659" alt="Screen Shot 2021-10-29 at 12 53 47" src="https://user-images.githubusercontent.com/254753/139422759-787802eb-9f12-4810-9cd2-b40768e51b2e.png">

