### PR TITLE
Merge hotfix from previous release cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [5.0.1](https://github.com/UN-OCHA/hid_api/compare/v5.0.0...v5.0.1) (2021-10-28)
+
+
+### Bug Fixes
+
+* **security:** only destroy session after password reset succeeds ([0d30eea](https://github.com/UN-OCHA/hid_api/commit/0d30eea40ccb7ea199cdfffea58b0582c6313d7e))
+
+## [4.0.0](https://github.com/UN-OCHA/hid_api/compare/v4.0.0-rc1...v4.0.0) (2021-09-16)
+
 ## [5.0.0](https://github.com/UN-OCHA/hid_api/compare/v4.0.0-rc1...v5.0.0) (2021-10-20)
 
 

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 4.0.0
+  version: 5.0.1
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid_api.git",


### PR DESCRIPTION
We'd tagged `v5.0.0` and during our 2-week stage window, I noticed a regression. I tagged a hotfix and that was `v5.0.1` and this folds it back into our `dev` branch.