### PR TITLE
HID-2279: implement password dictionary test whenever passwords are being chosen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /srv/www
 COPY . .
 
 RUN cp run_node /etc/services.d/node/run && \
-    apk add cracklib && \
-    apk add --virtual .build-deps python3 python3-dev build-base cracklib-dev && \
+    apk add cracklib cracklib-dev && \
+    apk add --virtual .build-deps python3 python3-dev build-base && \
     npm install && \
     npm run docs && \
     apk del .build-deps && \

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -598,6 +598,10 @@ module.exports = {
           request,
           security: true,
           fail: true,
+          user: {
+            id: user.id,
+            email: user.email,
+          },
         },
       );
       throw Boom.badRequest('Request is missing parameters (old_password or new_password)');
@@ -611,6 +615,10 @@ module.exports = {
           request,
           security: true,
           fail: true,
+          user: {
+            id: user.id,
+            email: user.email,
+          },
         },
       );
       throw Boom.badRequest('New password does not meet requirements');
@@ -625,6 +633,10 @@ module.exports = {
           request,
           security: true,
           fail: true,
+          user: {
+            id: user.id,
+            email: user.email,
+          },
         },
       );
       throw Boom.badRequest('New password does not meet requirements');
@@ -638,6 +650,10 @@ module.exports = {
           request,
           security: true,
           fail: true,
+          user: {
+            id: user.id,
+            email: user.email,
+          },
         },
       );
       throw Boom.badRequest('The old password is wrong');
@@ -652,6 +668,10 @@ module.exports = {
           request,
           security: true,
           fail: true,
+          user: {
+            id: user.id,
+            email: user.email,
+          },
         },
       );
       throw Boom.badRequest('New password must be different than previous passwords');
@@ -1486,6 +1506,10 @@ module.exports = {
           request,
           security: true,
           fail: true,
+          user: {
+            id: user.id,
+            email: user.email,
+          },
         },
       );
       throw Boom.badRequest(resetLinkInvalidMessage);
@@ -1499,6 +1523,10 @@ module.exports = {
           request,
           security: true,
           fail: true,
+          user: {
+            id: user.id,
+            email: user.email,
+          },
         },
       );
       throw Boom.badRequest(cannotResetPasswordMessage);
@@ -1587,7 +1615,7 @@ module.exports = {
     // Update user in DB.
     await user.save().then(() => {
       logger.info(
-        '[UserController->resetPassword] Password updated successfully',
+        '[UserController->resetPassword] Password updated successfully.',
         {
           request,
           security: true,

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -12,7 +12,6 @@ const config = require('../../config/env');
 
 const { logger } = config;
 
-
 module.exports = {
   /*
    * @api [post] /user
@@ -619,7 +618,7 @@ module.exports = {
 
     // Run the potential password through our dictionary to weed out simple
     // substitutions and the like.
-    if (!User.isStrongDictionary(newPassword)) {
+    if (!user.isStrongDictionary(newPassword)) {
       logger.warn(
         `[UserController->updatePassword] Could not update user password for user ${userId}. Password failed the dictionary test.`,
         {
@@ -1505,11 +1504,11 @@ module.exports = {
       throw Boom.badRequest(cannotResetPasswordMessage);
     }
 
-    // Compare new password to the old one. If our comparison is TRUE, then the
-    // reset attempt should be rejected, since the passwords are the same.
-    if (user.isHistoricalPassword(request.payload.password)) {
+    // Run the potential password through our dictionary to weed out simple
+    // substitutions and the like.
+    if (!user.isStrongDictionary(request.payload.password)) {
       logger.warn(
-        '[UserController->resetPassword] Could not reset password. New password must be different than previous passwords.',
+        '[UserController->resetPassword] Could not reset password. Password failed the dictionary test.',
         {
           request,
           security: true,
@@ -1523,11 +1522,11 @@ module.exports = {
       throw Boom.badRequest(cannotResetPasswordMessage);
     }
 
-    // Run the potential password through our dictionary to weed out simple
-    // substitutions and the like.
-    if (!User.isStrongDictionary(request.payload.password)) {
+    // Compare new password to the old one. If our comparison is TRUE, then the
+    // reset attempt should be rejected, since the passwords are the same.
+    if (user.isHistoricalPassword(request.payload.password)) {
       logger.warn(
-        '[UserController->resetPassword] Could not reset password. Password failed the dictionary test.',
+        '[UserController->resetPassword] Could not reset password. New password must be different than previous passwords.',
         {
           request,
           security: true,

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -506,7 +506,7 @@ UserSchema.methods = {
     const results = comparisons.map(thisComparison => {
       let thisResult;
 
-      // Do direct string comparison, whichthe library doesn't always catch if
+      // Do direct string comparison, which the library doesn't always catch if
       // enough randomness is tacked onto the end.
       thisResult = password.toLowerCase().indexOf(thisComparison.toLowerCase()) !== -1 ? 'exact string match found' : false;
 

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -10,6 +10,7 @@ const validate = require('mongoose-validator');
 const Bcrypt = require('bcryptjs');
 const crypto = require('crypto');
 const isHTML = require('is-html');
+const cracklib = require('cracklib');
 
 const { Schema } = mongoose;
 const populateClients = [
@@ -421,6 +422,28 @@ UserSchema.statics = {
     // eslint-disable-next-line no-useless-escape
     const regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()+=\\`{}[\]:";'< >?,.\/-]).+$/;
     return password.length >= 12 && regex.test(password);
+  },
+
+  /**
+   * Password dictionary test
+   *
+   * Check a password against a standard dictionary that does some substitutions
+   * involving numbers, compares against common patterns, and other well-known
+   * sources of "inspiration" for weak passwords.
+   *
+   * @return {boolean}
+   */
+  isStrongDictionary(password) {
+    // We use fascistCheckUser() and pass the email address in, so that any
+    // password incorporating that address gets rejected as well.
+    //
+    // The library returns an object with a `message` property. If that property
+    // is set to `null` then the password passed. If it contains a string then
+    // the password failed the dictionary test.
+    //
+    // We're not going to share why, so compare to `null` and get a boolean.
+    // If it returns `true` the password passed the dictionary test.
+    return cracklib.fascistCheckUser(password, this.email).message === null;
   },
 
   hashPassword(password) {

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -504,10 +504,21 @@ UserSchema.methods = {
 
     // Compare the password to all reference strings.
     const results = comparisons.map(thisComparison => {
+      let thisResult;
+
+      // Do direct string comparison, whichthe library doesn't always catch if
+      // enough randomness is tacked onto the end.
+      thisResult = password.toLowerCase().indexOf(thisComparison.toLowerCase()) !== -1 ? 'exact string match found' : false;
+
+      // Bail early if we found a really obvious match.
+      if (thisResult) {
+        return thisResult;
+      }
+
       // The library returns an object with a `message` property. If that property
       // is set to `null` then the password passed. If it contains a string then
       // the password failed the dictionary test.
-      const thisResult = cracklib.fascistCheckUser(password, thisComparison).message;
+      thisResult = cracklib.fascistCheckUser(password, thisComparison).message;
 
       // If the result is NOT `null` then it failed and we'll log the message
       // separate from the main operation taking place that invoked this function.

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -498,12 +498,12 @@ UserSchema.methods = {
       this.given_name,
       this.family_name,
     ];
-    this.emails.forEach(email => {
+    this.emails.forEach((email) => {
       comparisons.push(email.email);
-    })
+    });
 
     // Compare the password to all reference strings.
-    const results = comparisons.map(thisComparison => {
+    const results = comparisons.map((thisComparison) => {
       let thisResult;
 
       // Do direct string comparison, which the library doesn't always catch if

--- a/package-lock.json
+++ b/package-lock.json
@@ -5305,6 +5305,14 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cracklib": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cracklib/-/cracklib-1.1.0.tgz",
+      "integrity": "sha512-wXS/Ke7WIxV5XvO1g9RsxPJlp5aUGQecg0YAU3HyzIu9weWb55p7BVV1aqzrk4XLVfePhuiT/MDSv69+lj2q9g==",
+      "requires": {
+        "nan": "^2.14.2"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -10929,6 +10937,11 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "axios": "^0.21.2",
     "bcryptjs": "^2.3.0",
     "blankie": "^5.0.0",
+    "cracklib": "^1.1.0",
     "ejs": "^2.5.2",
     "email-templates": "^8.0.8",
     "hapi-rate-limit": "^4.0.2",


### PR DESCRIPTION
# HID-2279

The PR implements cracklib via node.js directly inside the API container. When choosing a new password we now compare to a dictionary which also does some normalization to convert 0 to o and other similar substitutions that don't provide much security to dictionary words. It has the option to compare to custom strings in addition to its dictionary and we're passing in the following successive strings:

- Given name
- Family name
- Each email address on the profile (regardless of confirmation status)

## Setup

@teodorescuserban tagging you to see if I did the docker stuff correctly. I believe it's good, because I deployed this branch to dev and everything looks like it works, including logs in ELK for dev env. Still, your 👀  are appreciated.

@orakili theoretically, rebuilding the API container will incorporate all dependencies. However if the thing crashes when you test it, I worked around this by manually running each command in the Dockerfile inside the API container. If the node.js process starts without crashing, you're in business.

## Testing

Reset the password for a user and try to create a couple weak passwords:

- Name1234567!
- user@example.com1

Also try some strong ones, e.g. from a password manager's generator.

No change to the information we disclose to the end user (via API or Auth UI). All new info about failures is log-only.